### PR TITLE
fix: fix unregister on quit

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -90,6 +90,10 @@ fn default_config_rtp_latching() -> Option<bool> {
     Some(true)
 }
 
+fn default_graceful_shutdown() -> Option<bool> {
+    Some(true)
+}
+
 fn default_config_useragent() -> Option<String> {
     Some(format!(
         "active-call({} miuda.ai)",
@@ -182,6 +186,7 @@ pub struct Config {
     #[serde(default = "default_config_useragent")]
     pub useragent: Option<String>,
     pub register_users: Option<Vec<RegisterOption>>,
+    #[serde(default = "default_graceful_shutdown")]
     pub graceful_shutdown: Option<bool>,
     pub handler: Option<InviteHandlerConfig>,
     pub accept_timeout: Option<String>,


### PR DESCRIPTION
Bug: Unregistration (Expires: 0) fails to handle 401 Authentication Challenge.

Fix: 

* ctrl+c wait for app_state.serve() complete
* move stop_registration into select
* use seprated cancel token for endpoint

Relate to:

https://github.com/restsend/rsipstack/pull/93

#10