### PR TITLE
feat: auto learn public address for sip

### DIFF
--- a/active-call.example.toml
+++ b/active-call.example.toml
@@ -29,6 +29,8 @@ media_cache_path = "./config/mediacache"
 # external IP address for SIP signaling and media
 # if server is behind NAT, set your public IP here (without port)
 # external_ip = "1.2.3.4"
+# auto learn public SIP address from Via received/rport in responses
+# auto_learn_public_address = true
 
 # rtp_start_port = 20000
 # rtp_end_port = 30000

--- a/src/app.rs
+++ b/src/app.rs
@@ -11,6 +11,9 @@ use crate::{
             FnCreateInvitationHandler, PendingDialog, PendingDialogGuard,
             default_create_invite_handler,
         },
+        public_address::{
+            LearnedPublicAddresses, LearningMessageInspector, build_public_contact_uri,
+        },
         registration::{RegistrationHandle, UserCredential},
     },
 };
@@ -52,6 +55,7 @@ pub struct AppStateInner {
     pub invitation: Invitation,
     pub routing_state: Arc<crate::call::RoutingState>,
     pub pending_playbooks: Arc<Mutex<HashMap<String, (String, std::time::Instant)>>>,
+    pub learned_public_addresses: LearnedPublicAddresses,
 
     pub active_calls: Arc<std::sync::Mutex<HashMap<String, ActiveCallRef>>>,
     pub total_calls: AtomicU64,
@@ -77,6 +81,10 @@ pub struct AppStateBuilder {
 }
 
 impl AppStateInner {
+    pub fn auto_learn_public_address_enabled(&self) -> bool {
+        self.config.auto_learn_public_address.unwrap_or(false)
+    }
+
     pub fn get_dump_events_file(&self, session_id: &String) -> String {
         let recorder_root = self.config.recorder_path();
         let root = Path::new(&recorder_root);
@@ -294,17 +302,22 @@ impl AppStateInner {
                             continue;
                         }
                     };
-                    let contact = dialog_layer
-                        .endpoint
-                        .get_addrs()
-                        .first()
-                        .map(|addr| rsip::Uri {
-                            scheme: Some(rsip::Scheme::Sip),
-                            auth: None,
-                            host_with_port: addr.addr.clone(),
-                            params: vec![],
-                            headers: vec![],
-                        });
+                    let local_addr = tx
+                        .connection
+                        .as_ref()
+                        .map(|connection| connection.get_addr().clone())
+                        .or_else(|| dialog_layer.endpoint.get_addrs().first().cloned());
+                    let contact_username =
+                        tx.original.uri.auth.as_ref().map(|auth| auth.user.as_str());
+                    let contact = local_addr.as_ref().map(|addr| {
+                        build_public_contact_uri(
+                            &self.learned_public_addresses,
+                            self.auto_learn_public_address_enabled(),
+                            addr,
+                            contact_username,
+                            None,
+                        )
+                    });
 
                     let dialog = match dialog_layer.get_or_create_server_invite(
                         &tx,
@@ -734,6 +747,7 @@ impl AppStateBuilder {
             .cancel_token
             .unwrap_or_else(|| CancellationToken::new());
         let _ = set_cache_dir(&config.media_cache_path);
+        let learned_public_addresses = LearnedPublicAddresses::default();
 
         let local_ip = if !config.addr.is_empty() {
             std::net::IpAddr::from_str(config.addr.as_str())?
@@ -866,7 +880,13 @@ impl AppStateBuilder {
             .with_transport_layer(transport_layer)
             .with_option(endpoint_option);
 
-        if let Some(inspector) = self.message_inspector {
+        if config.auto_learn_public_address.unwrap_or(false) {
+            endpoint_builder =
+                endpoint_builder.with_inspector(Box::new(LearningMessageInspector::new(
+                    learned_public_addresses.clone(),
+                    self.message_inspector,
+                )));
+        } else if let Some(inspector) = self.message_inspector {
             endpoint_builder = endpoint_builder.with_inspector(inspector);
         }
 
@@ -929,6 +949,7 @@ impl AppStateBuilder {
             invitation: Invitation::new(dialog_layer),
             routing_state: Arc::new(crate::call::RoutingState::new()),
             pending_playbooks: Arc::new(Mutex::new(HashMap::new())),
+            learned_public_addresses,
             active_calls: Arc::new(std::sync::Mutex::new(HashMap::new())),
             total_calls: AtomicU64::new(0),
             total_failed_calls: AtomicU64::new(0),

--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -29,7 +29,10 @@ use crate::{
         sip::{DialogStateReceiverGuard, Invitation, InviteDialogStates},
     },
     callrecord::{CallRecord, CallRecordEvent, CallRecordEventType, CallRecordHangupReason},
-    useragent::invitation::PendingDialog,
+    useragent::{
+        invitation::PendingDialog,
+        public_address::{build_public_contact_uri, contact_needs_public_resolution},
+    },
 };
 use anyhow::Result;
 use audio_codec::CodecType;
@@ -2035,22 +2038,29 @@ impl ActiveCall {
 
         // Set contact to local SIP endpoint address if not already set explicitly
         // Check if contact is still default (no scheme set) or if host is localhost-like
-        let needs_contact = invite_option.contact.scheme.is_none()
-            || invite_option
-                .contact
-                .host_with_port
-                .to_string()
-                .starts_with("127.0.0.1");
+        let needs_contact = contact_needs_public_resolution(&invite_option.contact);
 
         if needs_contact {
             if let Some(addr) = self.invitation.dialog_layer.endpoint.get_addrs().first() {
-                invite_option.contact = rsip::Uri {
-                    scheme: Some(rsip::Scheme::Sip),
-                    auth: None,
-                    host_with_port: addr.addr.clone(),
-                    params: vec![],
-                    headers: vec![],
-                };
+                let contact_username = invite_option
+                    .contact
+                    .auth
+                    .as_ref()
+                    .map(|auth| auth.user.as_str())
+                    .or_else(|| {
+                        invite_option
+                            .caller
+                            .auth
+                            .as_ref()
+                            .map(|auth| auth.user.as_str())
+                    });
+                invite_option.contact = build_public_contact_uri(
+                    &self.app_state.learned_public_addresses,
+                    self.app_state.auto_learn_public_address_enabled(),
+                    addr,
+                    contact_username,
+                    Some(&invite_option.contact),
+                );
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -177,6 +177,7 @@ pub struct Config {
     pub http_addr: String,
     pub addr: String,
     pub udp_port: u16,
+    pub auto_learn_public_address: Option<bool>,
 
     pub log_level: Option<String>,
     pub log_file: Option<String>,
@@ -299,6 +300,7 @@ impl Default for Config {
             http_access_skip_paths: Vec::new(),
             addr: default_sip_addr(),
             udp_port: default_sip_port(),
+            auto_learn_public_address: None,
             useragent: None,
             register_users: None,
             graceful_shutdown: Some(true),

--- a/src/useragent/mod.rs
+++ b/src/useragent/mod.rs
@@ -1,6 +1,7 @@
 pub mod registration;
 pub use registration::RegisterOption;
 pub mod invitation;
-pub mod webhook;
 pub mod playbook_handler;
+pub mod public_address;
+pub mod webhook;
 pub use playbook_handler::PlaybookInvitationHandler;

--- a/src/useragent/public_address.rs
+++ b/src/useragent/public_address.rs
@@ -1,0 +1,270 @@
+use rsip::{headers::ToTypedHeader, prelude::HeadersExt};
+use rsipstack::{
+    rsip_ext::RsipResponseExt, transaction::endpoint::MessageInspector, transport::SipAddr,
+};
+use std::{
+    collections::HashMap,
+    net::IpAddr,
+    sync::{Arc, RwLock},
+};
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct LearnedPublicAddress {
+    pub transport: rsip::Transport,
+    pub host_with_port: rsip::HostWithPort,
+}
+
+#[derive(Clone, Default)]
+pub struct LearnedPublicAddresses {
+    inner: Arc<RwLock<HashMap<rsip::Transport, rsip::HostWithPort>>>,
+}
+
+impl LearnedPublicAddresses {
+    pub fn store(
+        &self,
+        transport: Option<&rsip::Transport>,
+        host_with_port: rsip::HostWithPort,
+    ) -> bool {
+        let transport = normalize_transport(transport);
+        let mut guard = self.inner.write().unwrap();
+        if guard.get(&transport) == Some(&host_with_port) {
+            return false;
+        }
+        guard.insert(transport, host_with_port);
+        true
+    }
+
+    pub fn get(&self, transport: Option<&rsip::Transport>) -> Option<rsip::HostWithPort> {
+        let transport = normalize_transport(transport);
+        self.inner.read().unwrap().get(&transport).cloned()
+    }
+
+    pub fn learn_from_response(&self, response: &rsip::Response) -> Option<LearnedPublicAddress> {
+        let host_with_port = response.via_received()?;
+        let transport = response
+            .via_header()
+            .ok()
+            .and_then(|via| via.typed().ok())
+            .map(|via| via.transport)
+            .unwrap_or(rsip::Transport::Udp);
+        self.store(Some(&transport), host_with_port.clone());
+        Some(LearnedPublicAddress {
+            transport,
+            host_with_port,
+        })
+    }
+}
+
+pub fn normalize_transport(transport: Option<&rsip::Transport>) -> rsip::Transport {
+    transport.cloned().unwrap_or(rsip::Transport::Udp)
+}
+
+pub fn transport_for_uri(uri: &rsip::Uri) -> rsip::Transport {
+    if matches!(uri.scheme, Some(rsip::Scheme::Sips)) {
+        return rsip::Transport::Tls;
+    }
+
+    uri.params
+        .iter()
+        .find_map(|param| match param {
+            rsip::Param::Transport(transport) => Some(transport.clone()),
+            _ => None,
+        })
+        .unwrap_or(rsip::Transport::Udp)
+}
+
+pub fn contact_needs_public_resolution(contact: &rsip::Uri) -> bool {
+    if contact.scheme.is_none() {
+        return true;
+    }
+
+    match &contact.host_with_port.host {
+        rsip::Host::Domain(domain) => {
+            let host = domain.to_string();
+            host.eq_ignore_ascii_case("localhost")
+        }
+        rsip::Host::IpAddr(ip) => is_local_or_unspecified(ip),
+    }
+}
+
+pub fn build_contact_uri(
+    local_addr: &SipAddr,
+    learned_addr: Option<rsip::HostWithPort>,
+    username: Option<&str>,
+    template: Option<&rsip::Uri>,
+) -> rsip::Uri {
+    let mut uri = template
+        .cloned()
+        .unwrap_or_else(|| rsip::Uri::from(local_addr));
+
+    uri.host_with_port = learned_addr.unwrap_or_else(|| local_addr.addr.clone());
+    if uri.scheme.is_none() {
+        uri.scheme = Some(match local_addr.r#type {
+            Some(rsip::Transport::Tls)
+            | Some(rsip::Transport::Wss)
+            | Some(rsip::Transport::TlsSctp) => rsip::Scheme::Sips,
+            _ => rsip::Scheme::Sip,
+        });
+    }
+
+    if uri.auth.is_none() {
+        if let Some(username) = username.filter(|value| !value.is_empty()) {
+            uri.auth = Some(rsip::Auth {
+                user: username.to_string(),
+                password: None,
+            });
+        }
+    }
+
+    uri
+}
+
+pub fn build_public_contact_uri(
+    learned_public_addresses: &LearnedPublicAddresses,
+    auto_learn_public_address: bool,
+    local_addr: &SipAddr,
+    username: Option<&str>,
+    template: Option<&rsip::Uri>,
+) -> rsip::Uri {
+    let learned_addr = if auto_learn_public_address {
+        learned_public_addresses.get(local_addr.r#type.as_ref())
+    } else {
+        None
+    };
+    build_contact_uri(local_addr, learned_addr, username, template)
+}
+
+pub struct LearningMessageInspector {
+    learned_public_addresses: LearnedPublicAddresses,
+    next: Option<Box<dyn MessageInspector>>,
+}
+
+impl LearningMessageInspector {
+    pub fn new(
+        learned_public_addresses: LearnedPublicAddresses,
+        next: Option<Box<dyn MessageInspector>>,
+    ) -> Self {
+        Self {
+            learned_public_addresses,
+            next,
+        }
+    }
+}
+
+impl MessageInspector for LearningMessageInspector {
+    fn before_send(&self, msg: rsip::SipMessage, dest: Option<&SipAddr>) -> rsip::SipMessage {
+        if let Some(next) = &self.next {
+            next.before_send(msg, dest)
+        } else {
+            msg
+        }
+    }
+
+    fn after_received(&self, msg: rsip::SipMessage, from: &SipAddr) -> rsip::SipMessage {
+        let msg = if let Some(next) = &self.next {
+            next.after_received(msg, from)
+        } else {
+            msg
+        };
+
+        if let rsip::SipMessage::Response(response) = &msg {
+            self.learned_public_addresses.learn_from_response(response);
+        }
+
+        msg
+    }
+}
+
+fn is_local_or_unspecified(ip: &IpAddr) -> bool {
+    ip.is_loopback() || ip.is_unspecified()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        LearnedPublicAddresses, build_contact_uri, build_public_contact_uri,
+        contact_needs_public_resolution, transport_for_uri,
+    };
+    use rsip::transport::Transport;
+    use rsipstack::transport::SipAddr;
+
+    #[test]
+    fn learns_public_address_from_response_via() {
+        let cache = LearnedPublicAddresses::default();
+        let response: rsip::Response = concat!(
+            "SIP/2.0 401 Unauthorized\r\n",
+            "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-1;received=203.0.113.10;rport=62000\r\n",
+            "Content-Length: 0\r\n",
+            "\r\n"
+        )
+        .try_into()
+        .unwrap();
+
+        let learned = cache.learn_from_response(&response).unwrap();
+        assert_eq!(learned.transport, Transport::Udp);
+        assert_eq!(learned.host_with_port.to_string(), "203.0.113.10:62000");
+        assert_eq!(
+            cache.get(Some(&Transport::Udp)).unwrap().to_string(),
+            "203.0.113.10:62000"
+        );
+    }
+
+    #[test]
+    fn builds_contact_using_learned_public_address() {
+        let local_addr = SipAddr {
+            r#type: Some(Transport::Udp),
+            addr: "10.0.0.5:5060"
+                .parse::<std::net::SocketAddr>()
+                .unwrap()
+                .into(),
+        };
+        let template: rsip::Uri = "sip:alice@127.0.0.1:5060".try_into().unwrap();
+        let learned_addr = Some(
+            "203.0.113.10:62000"
+                .parse::<std::net::SocketAddr>()
+                .unwrap()
+                .into(),
+        );
+
+        let contact = build_contact_uri(&local_addr, learned_addr, Some("alice"), Some(&template));
+        assert_eq!(contact.to_string(), "sip:alice@203.0.113.10:62000");
+    }
+
+    #[test]
+    fn identifies_contacts_that_need_resolution() {
+        let local_contact: rsip::Uri = "sip:alice@127.0.0.1:5060".try_into().unwrap();
+        let remote_contact: rsip::Uri = "sip:alice@203.0.113.10:62000".try_into().unwrap();
+        assert!(contact_needs_public_resolution(&local_contact));
+        assert!(!contact_needs_public_resolution(&remote_contact));
+    }
+
+    #[test]
+    fn builds_public_contact_from_shared_cache() {
+        let cache = LearnedPublicAddresses::default();
+        cache.store(
+            Some(&Transport::Udp),
+            "203.0.113.20:62000"
+                .parse::<std::net::SocketAddr>()
+                .unwrap()
+                .into(),
+        );
+        let local_addr = SipAddr {
+            r#type: Some(Transport::Udp),
+            addr: "10.0.0.5:5060"
+                .parse::<std::net::SocketAddr>()
+                .unwrap()
+                .into(),
+        };
+
+        let contact = build_public_contact_uri(&cache, true, &local_addr, Some("alice"), None);
+        assert_eq!(contact.to_string(), "sip:alice@203.0.113.20:62000");
+    }
+
+    #[test]
+    fn infers_transport_from_uri() {
+        let sips_uri: rsip::Uri = "sips:alice@example.com".try_into().unwrap();
+        let tcp_uri: rsip::Uri = "sip:alice@example.com;transport=tcp".try_into().unwrap();
+        assert_eq!(transport_for_uri(&sips_uri), Transport::Tls);
+        assert_eq!(transport_for_uri(&tcp_uri), Transport::Tcp);
+    }
+}


### PR DESCRIPTION
## Summary
- add an opt-in auto-learn public address option for SIP signaling
- learn the public address from SIP responses and reuse it when building contact URIs
- keep the feature at the app/useragent level instead of changing the current API shape