### PR TITLE
fix: false caching base64 tts

### DIFF
--- a/src/media/tests/tts_track.rs
+++ b/src/media/tests/tts_track.rs
@@ -1,6 +1,6 @@
 use crate::{
     event::SessionEvent,
-    media::Samples,
+    media::{Samples, cache},
     media::track::{Track, tts::TtsTrack},
     synthesis::{
         Subtitle, SynthesisClient, SynthesisCommand, SynthesisEvent, SynthesisOption, SynthesisType,
@@ -12,6 +12,7 @@ use bytes::BufMut;
 use bytes::Bytes;
 use futures::StreamExt;
 use futures::stream::BoxStream;
+use std::path::PathBuf;
 use std::time::Instant;
 use tokio::{
     sync::{broadcast, mpsc},
@@ -537,6 +538,11 @@ async fn test_tts_track_end_of_stream() -> Result<()> {
 
 #[tokio::test]
 async fn test_tts_track_base64() -> Result<()> {
+    let original_cache_dir = cache::get_cache_dir()?;
+    let temp_dir = tempfile::tempdir()?;
+    let test_cache_dir = temp_dir.path().join("mediacache");
+    cache::set_cache_dir(test_cache_dir.to_str().unwrap())?;
+
     // Create a command channel
     let (command_tx, command_rx) = mpsc::unbounded_channel();
 
@@ -609,5 +615,12 @@ async fn test_tts_track_base64() -> Result<()> {
     }
 
     assert!(sample_received >= 8000, "Not enough bytes");
+    let leaked_cache_file = PathBuf::from(format!("{}.pcm", test_cache_dir.display()));
+    assert!(
+        !tokio::fs::try_exists(&leaked_cache_file).await?,
+        "base64 playback should not create an empty-key cache file at {}",
+        leaked_cache_file.display()
+    );
+    cache::set_cache_dir(original_cache_dir.to_str().unwrap())?;
     Ok(())
 }

--- a/src/media/track/tts.rs
+++ b/src/media/track/tts.rs
@@ -730,6 +730,7 @@ impl TtsTask {
 
                 // if cache is enabled, cache key set by handle_cache
                 if self.cache_enabled
+                    && !entry.cache_key.is_empty()
                     && !cache::is_cached(&entry.cache_key).await.unwrap_or_default()
                 {
                     if let Err(e) =
@@ -755,6 +756,8 @@ impl TtsTask {
                             "stored audio in cache"
                         );
                     }
+                    entry.chunks.clear();
+                } else if self.cache_enabled && entry.cache_key.is_empty() {
                     entry.chunks.clear();
                 }
 


### PR DESCRIPTION
## Summary
- skip TTS cache writes when the cache key is empty
- fix test will creating file "config/mediacache.pcm"