### PR TITLE
improve: refactor learning address

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 minijinja = { version = "2.17.1", features = ["loader", "json"] }
 anyhow = "1"
+arc-swap = "1.8.2"
 async-trait = "0.1.88"
 async-stream = "0.3.6"
 axum = { version = "0.8.7", features = ["ws", "tokio", "multipart"] }

--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,8 @@ use crate::{
             default_create_invite_handler,
         },
         public_address::{
-            LearnedPublicAddresses, LearningMessageInspector, build_public_contact_uri,
+            LearningMessageInspector, SharedPublicAddress, build_contact, build_public_contact_uri,
+            find_local_addr_for_uri,
         },
         registration::{RegistrationHandle, UserCredential},
     },
@@ -20,7 +21,9 @@ use crate::{
 
 use crate::media::{cache::set_cache_dir, engine::StreamEngine};
 use anyhow::Result;
+use arc_swap::ArcSwap;
 use chrono::{DateTime, Local};
+use futures::FutureExt;
 use humantime::parse_duration;
 use rsip::prelude::HeadersExt;
 use rsipstack::transaction::{
@@ -28,11 +31,12 @@ use rsipstack::transaction::{
     endpoint::{TargetLocator, TransportEventInspector},
 };
 use rsipstack::{dialog::dialog_layer::DialogLayer, transaction::endpoint::MessageInspector};
-use std::collections::HashSet;
+use std::future::pending;
 use std::str::FromStr;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use std::{collections::HashMap, net::SocketAddr};
+use std::{collections::HashSet, time::Instant};
 use std::{
     path::Path,
     sync::atomic::{AtomicBool, AtomicU64, Ordering},
@@ -48,14 +52,14 @@ pub struct AppStateInner {
     pub stream_engine: Arc<StreamEngine>,
     pub callrecord_sender: Option<CallRecordSender>,
     pub endpoint: Endpoint,
-    pub registration_handles: Mutex<HashMap<String, RegistrationHandle>>,
+    pub registration_handles: Mutex<HashMap<String, CancellationToken>>,
     pub alive_users: Arc<RwLock<HashSet<String>>>,
     pub dialog_layer: Arc<DialogLayer>,
     pub create_invitation_handler: Option<FnCreateInvitationHandler>,
     pub invitation: Invitation,
     pub routing_state: Arc<crate::call::RoutingState>,
-    pub pending_playbooks: Arc<Mutex<HashMap<String, (String, std::time::Instant)>>>,
-    pub learned_public_addresses: LearnedPublicAddresses,
+    pub pending_playbooks: Arc<Mutex<HashMap<String, (String, Instant)>>>,
+    pub learned_public_address: SharedPublicAddress,
 
     pub active_calls: Arc<std::sync::Mutex<HashMap<String, ActiveCallRef>>>,
     pub total_calls: AtomicU64,
@@ -311,7 +315,7 @@ impl AppStateInner {
                         tx.original.uri.auth.as_ref().map(|auth| auth.user.as_str());
                     let contact = local_addr.as_ref().map(|addr| {
                         build_public_contact_uri(
-                            &self.learned_public_addresses,
+                            &self.learned_public_address,
                             self.auto_learn_public_address_enabled(),
                             addr,
                             contact_username,
@@ -443,12 +447,12 @@ impl AppStateInner {
         info!("stopping, marking as shutting down");
         self.token.cancel();
     }
-    
+
     pub async fn graceful_stop(&self) -> Result<()> {
         if self.shutting_down.swap(true, Ordering::Relaxed) {
             return Ok(());
         }
-        
+
         info!("graceful stopping, marking as shutting down");
         let timeout = self
             .config
@@ -590,10 +594,9 @@ impl AppStateInner {
     pub async fn stop_registration(&self, wait_for_clear: Option<Duration>) -> Result<()> {
         {
             let mut handles = self.registration_handles.lock().await;
-            for (_, handle) in handles.iter_mut() {
-                handle.stop();
+            for (_, cancel_token) in handles.drain() {
+                cancel_token.cancel();
             }
-            handles.clear();
         }
 
         if let Some(duration) = wait_for_clear {
@@ -643,57 +646,114 @@ impl AppStateInner {
             self.endpoint.inner.clone(),
             credential,
         );
-        let handle = RegistrationHandle {
-            inner: Arc::new(crate::useragent::registration::RegistrationHandleInner {
-                registration: Mutex::new(registration),
-                option,
-                cancel_token,
-                start_time: Mutex::new(std::time::Instant::now()),
-                last_update: Mutex::new(std::time::Instant::now()),
-                last_response: Mutex::new(None),
-            }),
+        let mut handle = RegistrationHandle {
+            registration,
+            option,
+            cancel_token: cancel_token.clone(),
+            start_time: Instant::now(),
+            last_update: Instant::now(),
+            last_response: None,
         };
         self.registration_handles
             .lock()
             .await
-            .insert(user.clone(), handle.clone());
+            .insert(user.clone(), cancel_token);
         tracing::debug!(user = user.as_str(), "starting registration task");
         let alive_users = self.alive_users.clone();
 
         crate::spawn(async move {
-            *handle.inner.start_time.lock().await = std::time::Instant::now();
+            handle.start_time = Instant::now();
+            let cancel_token = handle.cancel_token.clone();
+            let addrs = handle.registration.endpoint.get_addrs();
+            let local_bind_addr = if let Some(addr) = find_local_addr_for_uri(&addrs, &sip_server) {
+                addr
+            } else {
+                warn!(
+                    user = user.as_str(),
+                    server = %sip_server,
+                    "failed to get local bind address for registration transport"
+                );
+                alive_users.write().unwrap().remove(&user);
+                return;
+            };
+            let user = handle.option.aor();
+            alive_users.write().unwrap().remove(&user);
+            let mut contact_address = local_bind_addr.addr.clone();
+            let mut contact = build_contact(
+                &local_bind_addr,
+                Some(contact_address.clone()),
+                Some(handle.option.username.as_str()),
+                None,
+            );
+            let mut should_register = true;
+            let mut timer = pending().boxed();
 
-            select! {
-                _ = handle.inner.cancel_token.cancelled() => {
-                }
-                _ = async {
-                    loop {
-                        let user = handle.inner.option.aor();
-                        alive_users.write().unwrap().remove(&user);
-                        let refresh_time = match handle.do_register(&sip_server, None).await {
-                            Ok(expires) => {
+            loop {
+                select! {
+                    _ = cancel_token.cancelled() => {
+                        break;
+                    }
+                    _ = timer.as_mut(), if !should_register => {
+                        should_register = true;
+                        timer = Box::pin(pending());
+                    }
+                    result = handle.do_register(&sip_server, None, &contact), if should_register => {
+                        match result {
+                            Ok((expires, new_addr)) => {
+                                if handle
+                                    .should_retry_registration_now(
+                                        &local_bind_addr,
+                                        &contact_address,
+                                        new_addr.as_ref(),
+                                    )
+                                {
+                                    if let Some(next_contact_address) = new_addr {
+                                        info!(
+                                            user = user.as_str(),
+                                            current_contact = %contact_address,
+                                            next_contact = %next_contact_address,
+                                            "public address changed, retrying registration immediately",
+                                        );
+                                        contact_address = next_contact_address;
+                                        contact = build_contact(
+                                            &local_bind_addr,
+                                            Some(contact_address.clone()),
+                                            Some(handle.option.username.as_str()),
+                                            None,
+                                        );
+                                        continue;
+                                    }
+                                }
                                 info!(
-                                    user = handle.inner.option.aor(),
+                                    user = user.as_str(),
                                     expires = expires,
+                                    contact = %contact_address,
                                     alive_users = alive_users.read().unwrap().len(),
                                     "registration refreshed",
                                 );
-                                alive_users.write().unwrap().insert(user);
-                                expires * 3 / 4 // 75% of expiration time
+                                alive_users.write().unwrap().insert(user.clone());
+                                should_register = false;
+                                timer = Box::pin(tokio::time::sleep(Duration::from_secs(
+                                    (expires * 3 / 4) as u64,
+                                )));
                             }
                             Err(e) => {
                                 warn!(
-                                    user = handle.inner.option.aor(),
+                                    user = user.as_str(),
                                     alive_users = alive_users.read().unwrap().len(),
-                                    "registration failed: {:?}", e);
-                                60
+                                    "registration failed: {:?}", e
+                                );
+                                should_register = false;
+                                timer = Box::pin(tokio::time::sleep(Duration::from_secs(60)));
                             }
-                        };
-                        tokio::time::sleep(Duration::from_secs(refresh_time as u64)).await;
+                        }
                     }
-                } => {}
+                }
             }
-            handle.do_register(&sip_server, Some(0)).await.ok();
+            handle
+                .do_register(&sip_server, Some(0), &contact)
+                .await
+                .ok();
             alive_users.write().unwrap().remove(&user);
         });
         Ok(())
@@ -770,8 +830,6 @@ impl AppStateBuilder {
             .cancel_token
             .unwrap_or_else(|| CancellationToken::new());
         let _ = set_cache_dir(&config.media_cache_path);
-        let learned_public_addresses = LearnedPublicAddresses::default();
-
         let local_ip = if !config.addr.is_empty() {
             std::net::IpAddr::from_str(config.addr.as_str())?
         } else {
@@ -819,6 +877,8 @@ impl AppStateBuilder {
         // Use the actual bound address (important when port=0 lets OS assign a port)
         let actual_addr = tokio_socket.local_addr()?;
         let bind_addr = rsipstack::transport::SipConnection::resolve_bind_address(actual_addr);
+        let mut learned_public_address: SharedPublicAddress =
+            Arc::new(ArcSwap::from_pointee(bind_addr.into()));
 
         let udp_inner = rsipstack::transport::udp::UdpInner {
             conn: tokio_socket,
@@ -903,12 +963,10 @@ impl AppStateBuilder {
             .with_transport_layer(transport_layer)
             .with_option(endpoint_option);
 
-        if config.auto_learn_public_address.unwrap_or(false) {
-            endpoint_builder =
-                endpoint_builder.with_inspector(Box::new(LearningMessageInspector::new(
-                    learned_public_addresses.clone(),
-                    self.message_inspector,
-                )));
+        if config.auto_learn_public_address.unwrap_or_default() {
+            let inspector = LearningMessageInspector::new(bind_addr.into(), self.message_inspector);
+            learned_public_address = inspector.shared_public_address();
+            endpoint_builder = endpoint_builder.with_inspector(Box::new(inspector));
         } else if let Some(inspector) = self.message_inspector {
             endpoint_builder = endpoint_builder.with_inspector(inspector);
         }
@@ -972,7 +1030,7 @@ impl AppStateBuilder {
             invitation: Invitation::new(dialog_layer),
             routing_state: Arc::new(crate::call::RoutingState::new()),
             pending_playbooks: Arc::new(Mutex::new(HashMap::new())),
-            learned_public_addresses,
+            learned_public_address,
             active_calls: Arc::new(std::sync::Mutex::new(HashMap::new())),
             total_calls: AtomicU64::new(0),
             total_failed_calls: AtomicU64::new(0),

--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -31,7 +31,9 @@ use crate::{
     callrecord::{CallRecord, CallRecordEvent, CallRecordEventType, CallRecordHangupReason},
     useragent::{
         invitation::PendingDialog,
-        public_address::{build_public_contact_uri, contact_needs_public_resolution},
+        public_address::{
+            build_public_contact_uri, contact_needs_public_resolution, find_local_addr_for_uri,
+        },
     },
 };
 use anyhow::Result;
@@ -2041,7 +2043,8 @@ impl ActiveCall {
         let needs_contact = contact_needs_public_resolution(&invite_option.contact);
 
         if needs_contact {
-            if let Some(addr) = self.invitation.dialog_layer.endpoint.get_addrs().first() {
+            let addrs = self.invitation.dialog_layer.endpoint.get_addrs();
+            if let Some(addr) = find_local_addr_for_uri(&addrs, &invite_option.callee) {
                 let contact_username = invite_option
                     .contact
                     .auth
@@ -2055,12 +2058,17 @@ impl ActiveCall {
                             .map(|auth| auth.user.as_str())
                     });
                 invite_option.contact = build_public_contact_uri(
-                    &self.app_state.learned_public_addresses,
+                    &self.app_state.learned_public_address,
                     self.app_state.auto_learn_public_address_enabled(),
-                    addr,
+                    &addr,
                     contact_username,
                     Some(&invite_option.contact),
                 );
+            } else {
+                return Err(rsipstack::Error::Error(format!(
+                    "missing local SIP address for callee transport: {}",
+                    invite_option.callee
+                )));
             }
         }
 

--- a/src/useragent/public_address.rs
+++ b/src/useragent/public_address.rs
@@ -1,59 +1,11 @@
+use arc_swap::ArcSwap;
 use rsip::{headers::ToTypedHeader, prelude::HeadersExt};
 use rsipstack::{
     rsip_ext::RsipResponseExt, transaction::endpoint::MessageInspector, transport::SipAddr,
 };
-use std::{
-    collections::HashMap,
-    net::IpAddr,
-    sync::{Arc, RwLock},
-};
+use std::{net::IpAddr, sync::Arc};
 
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct LearnedPublicAddress {
-    pub transport: rsip::Transport,
-    pub host_with_port: rsip::HostWithPort,
-}
-
-#[derive(Clone, Default)]
-pub struct LearnedPublicAddresses {
-    inner: Arc<RwLock<HashMap<rsip::Transport, rsip::HostWithPort>>>,
-}
-
-impl LearnedPublicAddresses {
-    pub fn store(
-        &self,
-        transport: Option<&rsip::Transport>,
-        host_with_port: rsip::HostWithPort,
-    ) -> bool {
-        let transport = normalize_transport(transport);
-        let mut guard = self.inner.write().unwrap();
-        if guard.get(&transport) == Some(&host_with_port) {
-            return false;
-        }
-        guard.insert(transport, host_with_port);
-        true
-    }
-
-    pub fn get(&self, transport: Option<&rsip::Transport>) -> Option<rsip::HostWithPort> {
-        let transport = normalize_transport(transport);
-        self.inner.read().unwrap().get(&transport).cloned()
-    }
-
-    pub fn learn_from_response(&self, response: &rsip::Response) -> Option<LearnedPublicAddress> {
-        let host_with_port = response.via_received()?;
-        let transport = response
-            .via_header()
-            .ok()
-            .and_then(|via| via.typed().ok())
-            .map(|via| via.transport)
-            .unwrap_or(rsip::Transport::Udp);
-        self.store(Some(&transport), host_with_port.clone());
-        Some(LearnedPublicAddress {
-            transport,
-            host_with_port,
-        })
-    }
-}
+pub type SharedPublicAddress = Arc<ArcSwap<rsip::HostWithPort>>;
 
 pub fn normalize_transport(transport: Option<&rsip::Transport>) -> rsip::Transport {
     transport.cloned().unwrap_or(rsip::Transport::Udp)
@@ -71,6 +23,13 @@ pub fn transport_for_uri(uri: &rsip::Uri) -> rsip::Transport {
             _ => None,
         })
         .unwrap_or(rsip::Transport::Udp)
+}
+
+pub fn find_local_addr_for_uri(addrs: &[SipAddr], uri: &rsip::Uri) -> Option<SipAddr> {
+    let transport = transport_for_uri(uri);
+    addrs.iter()
+        .find(|addr| normalize_transport(addr.r#type.as_ref()) == transport)
+        .cloned()
 }
 
 pub fn contact_needs_public_resolution(contact: &rsip::Uri) -> bool {
@@ -119,35 +78,55 @@ pub fn build_contact_uri(
     uri
 }
 
+pub fn build_contact(
+    local_addr: &SipAddr,
+    contact_address: Option<rsip::HostWithPort>,
+    username: Option<&str>,
+    template: Option<&rsip::Uri>,
+) -> rsip::typed::Contact {
+    let contact_uri = build_contact_uri(local_addr, contact_address, username, template);
+    rsip::typed::Contact {
+        display_name: None,
+        uri: contact_uri,
+        params: vec![],
+    }
+}
+
 pub fn build_public_contact_uri(
-    learned_public_addresses: &LearnedPublicAddresses,
+    learned_public_address: &SharedPublicAddress,
     auto_learn_public_address: bool,
     local_addr: &SipAddr,
     username: Option<&str>,
     template: Option<&rsip::Uri>,
 ) -> rsip::Uri {
-    let learned_addr = if auto_learn_public_address {
-        learned_public_addresses.get(local_addr.r#type.as_ref())
+    let selected_addr = if auto_learn_public_address
+        && normalize_transport(local_addr.r#type.as_ref()) == rsip::Transport::Udp
+    {
+        Some(learned_public_address.load_full().as_ref().clone())
     } else {
-        None
+        Some(local_addr.addr.clone())
     };
-    build_contact_uri(local_addr, learned_addr, username, template)
+    build_contact_uri(local_addr, selected_addr, username, template)
 }
 
 pub struct LearningMessageInspector {
-    learned_public_addresses: LearnedPublicAddresses,
+    learned_public_address: SharedPublicAddress,
     next: Option<Box<dyn MessageInspector>>,
 }
 
 impl LearningMessageInspector {
     pub fn new(
-        learned_public_addresses: LearnedPublicAddresses,
+        initial_address: rsip::HostWithPort,
         next: Option<Box<dyn MessageInspector>>,
     ) -> Self {
         Self {
-            learned_public_addresses,
+            learned_public_address: Arc::new(ArcSwap::from_pointee(initial_address)),
             next,
         }
+    }
+
+    pub fn shared_public_address(&self) -> SharedPublicAddress {
+        self.learned_public_address.clone()
     }
 }
 
@@ -161,17 +140,48 @@ impl MessageInspector for LearningMessageInspector {
     }
 
     fn after_received(&self, msg: rsip::SipMessage, from: &SipAddr) -> rsip::SipMessage {
-        let msg = if let Some(next) = &self.next {
+        if let rsip::SipMessage::Response(response) = &msg
+            && let Ok(via) = response.via_header()
+            && let Ok(via) = via.typed()
+            && via.transport == rsip::Transport::Udp
+            && let Some(host_with_port) = response.via_received()
+        {
+            self.learned_public_address
+                .rcu(|previous: &Arc<rsip::HostWithPort>| {
+                    if should_update_address(previous.as_ref(), &host_with_port) {
+                        Arc::new(host_with_port.clone())
+                    } else {
+                        previous.clone()
+                    }
+                });
+        }
+
+        if let Some(next) = &self.next {
             next.after_received(msg, from)
         } else {
             msg
-        };
-
-        if let rsip::SipMessage::Response(response) = &msg {
-            self.learned_public_addresses.learn_from_response(response);
         }
+    }
+}
 
-        msg
+pub fn should_update_address(
+    previous: &rsip::HostWithPort,
+    current: &rsip::HostWithPort,
+) -> bool {
+    if previous == current {
+        return false;
+    }
+
+    let previous_is_public = is_public_address(previous);
+    let current_is_public = is_public_address(current);
+    (!previous_is_public && current_is_public)
+        || (previous_is_public && current_is_public && previous != current)
+}
+
+fn is_public_address(host_with_port: &rsip::HostWithPort) -> bool {
+    match &host_with_port.host {
+        rsip::Host::Domain(domain) => !domain.to_string().eq_ignore_ascii_case("localhost"),
+        rsip::Host::IpAddr(ip) => !is_local_or_unspecified(ip),
     }
 }
 
@@ -182,15 +192,18 @@ fn is_local_or_unspecified(ip: &IpAddr) -> bool {
 #[cfg(test)]
 mod tests {
     use super::{
-        LearnedPublicAddresses, build_contact_uri, build_public_contact_uri,
-        contact_needs_public_resolution, transport_for_uri,
+        SharedPublicAddress, build_contact, build_contact_uri, build_public_contact_uri,
+        contact_needs_public_resolution, find_local_addr_for_uri, should_update_address,
+        transport_for_uri,
     };
+    use arc_swap::ArcSwap;
     use rsip::transport::Transport;
+    use rsipstack::transaction::endpoint::MessageInspector;
     use rsipstack::transport::SipAddr;
+    use std::sync::Arc;
 
     #[test]
     fn learns_public_address_from_response_via() {
-        let cache = LearnedPublicAddresses::default();
         let response: rsip::Response = concat!(
             "SIP/2.0 401 Unauthorized\r\n",
             "Via: SIP/2.0/UDP 10.0.0.1:5060;branch=z9hG4bK-1;received=203.0.113.10;rport=62000\r\n",
@@ -200,13 +213,25 @@ mod tests {
         .try_into()
         .unwrap();
 
-        let learned = cache.learn_from_response(&response).unwrap();
-        assert_eq!(learned.transport, Transport::Udp);
-        assert_eq!(learned.host_with_port.to_string(), "203.0.113.10:62000");
-        assert_eq!(
-            cache.get(Some(&Transport::Udp)).unwrap().to_string(),
-            "203.0.113.10:62000"
+        let inspector = super::LearningMessageInspector::new(
+            "127.0.0.1:5060"
+                .parse::<std::net::SocketAddr>()
+                .unwrap()
+                .into(),
+            None,
         );
+        let cache = inspector.shared_public_address();
+        inspector.after_received(
+            rsip::SipMessage::Response(response),
+            &SipAddr {
+                r#type: Some(Transport::Udp),
+                addr: "10.0.0.1:5060"
+                    .parse::<std::net::SocketAddr>()
+                    .unwrap()
+                    .into(),
+            },
+        );
+        assert_eq!(cache.load_full().as_ref().to_string(), "203.0.113.10:62000");
     }
 
     #[test]
@@ -239,15 +264,38 @@ mod tests {
     }
 
     #[test]
+    fn selects_local_addr_for_uri_transport() {
+        let addrs = vec![
+            SipAddr {
+                r#type: Some(Transport::Udp),
+                addr: "10.0.0.5:5060"
+                    .parse::<std::net::SocketAddr>()
+                    .unwrap()
+                    .into(),
+            },
+            SipAddr {
+                r#type: Some(Transport::Tls),
+                addr: "10.0.0.5:5061"
+                    .parse::<std::net::SocketAddr>()
+                    .unwrap()
+                    .into(),
+            },
+        ];
+
+        let uri: rsip::Uri = "sips:alice@example.com".try_into().unwrap();
+        let selected = find_local_addr_for_uri(&addrs, &uri).unwrap();
+
+        assert_eq!(selected.to_string(), "TLS 10.0.0.5:5061");
+    }
+
+    #[test]
     fn builds_public_contact_from_shared_cache() {
-        let cache = LearnedPublicAddresses::default();
-        cache.store(
-            Some(&Transport::Udp),
+        let cache: SharedPublicAddress = Arc::new(ArcSwap::from_pointee(
             "203.0.113.20:62000"
                 .parse::<std::net::SocketAddr>()
                 .unwrap()
                 .into(),
-        );
+        ));
         let local_addr = SipAddr {
             r#type: Some(Transport::Udp),
             addr: "10.0.0.5:5060"
@@ -261,10 +309,77 @@ mod tests {
     }
 
     #[test]
+    fn builds_typed_contact() {
+        let local_addr = SipAddr {
+            r#type: Some(Transport::Udp),
+            addr: "10.0.0.5:5060"
+                .parse::<std::net::SocketAddr>()
+                .unwrap()
+                .into(),
+        };
+        let contact = build_contact(
+            &local_addr,
+            Some(
+                "203.0.113.20:62000"
+                    .parse::<std::net::SocketAddr>()
+                    .unwrap()
+                    .into(),
+            ),
+            Some("alice"),
+            None,
+        );
+        assert_eq!(contact.to_string(), "<sip:alice@203.0.113.20:62000>");
+    }
+
+    #[test]
+    fn keeps_configured_contact_for_tls() {
+        let cache: SharedPublicAddress = Arc::new(ArcSwap::from_pointee(
+            "203.0.113.20:62000"
+                .parse::<std::net::SocketAddr>()
+                .unwrap()
+                .into(),
+        ));
+        let local_addr = SipAddr {
+            r#type: Some(Transport::Tls),
+            addr: "10.0.0.5:5061"
+                .parse::<std::net::SocketAddr>()
+                .unwrap()
+                .into(),
+        };
+
+        let contact = build_public_contact_uri(&cache, true, &local_addr, Some("alice"), None);
+        assert_eq!(contact.to_string(), "sips:alice@10.0.0.5:5061;transport=TLS");
+    }
+
+    #[test]
     fn infers_transport_from_uri() {
         let sips_uri: rsip::Uri = "sips:alice@example.com".try_into().unwrap();
         let tcp_uri: rsip::Uri = "sip:alice@example.com;transport=tcp".try_into().unwrap();
         assert_eq!(transport_for_uri(&sips_uri), Transport::Tls);
         assert_eq!(transport_for_uri(&tcp_uri), Transport::Tcp);
+    }
+
+    #[test]
+    fn updates_learned_address_from_local_to_public() {
+        let previous: rsip::HostWithPort = "127.0.0.1:5060"
+            .parse::<std::net::SocketAddr>()
+            .unwrap()
+            .into();
+        let current: rsip::HostWithPort = "203.0.113.10:62000"
+            .parse::<std::net::SocketAddr>()
+            .unwrap()
+            .into();
+
+        assert!(should_update_address(&previous, &current,));
+    }
+
+    #[test]
+    fn does_not_update_learned_address_when_unchanged() {
+        let current: rsip::HostWithPort = "203.0.113.10:62000"
+            .parse::<std::net::SocketAddr>()
+            .unwrap()
+            .into();
+
+        assert!(!should_update_address(&current, &current,));
     }
 }

--- a/src/useragent/registration.rs
+++ b/src/useragent/registration.rs
@@ -1,14 +1,15 @@
 use anyhow::Result;
-use rsip::{Response, StatusCodeKind};
+use rsip::{HostWithPort, Response, StatusCodeKind, Transport};
 use rsipstack::{
     dialog::{authenticate::Credential, registration::Registration},
-    rsip_ext::RsipResponseExt,
+    rsip_ext::RsipResponseExt, transport::SipAddr,
 };
 use serde::{Deserialize, Serialize};
-use std::{sync::Arc, time::Instant};
-use tokio::sync::Mutex;
+use std::time::Instant;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, warn};
+
+use super::public_address::{normalize_transport, should_update_address};
 
 #[derive(Debug, Deserialize, Clone, Serialize)]
 pub struct UserCredential {
@@ -42,27 +43,39 @@ impl RegisterOption {
     }
 }
 
-pub struct RegistrationHandleInner {
-    pub registration: Mutex<Registration>,
+pub struct RegistrationHandle {
+    pub registration: Registration,
     pub option: RegisterOption,
     pub cancel_token: CancellationToken,
-    pub start_time: Mutex<Instant>,
-    pub last_update: Mutex<Instant>,
-    pub last_response: Mutex<Option<Response>>,
-}
-#[derive(Clone)]
-pub struct RegistrationHandle {
-    pub inner: Arc<RegistrationHandleInner>,
+    pub start_time: Instant,
+    pub last_update: Instant,
+    pub last_response: Option<Response>,
 }
 
 impl RegistrationHandle {
-    pub fn stop(&self) {
-        self.inner.cancel_token.cancel();
+    pub fn should_retry_registration_now(
+        &self,
+        local_addr: &SipAddr,
+        current_contact_address: &HostWithPort,
+        discovered_public_address: Option<&HostWithPort>,
+    ) -> bool {
+        if normalize_transport(local_addr.r#type.as_ref()) != Transport::Udp {
+            return false;
+        }
+
+        discovered_public_address
+            .is_some_and(|address| should_update_address(current_contact_address, address))
     }
 
-    pub async fn do_register(&self, sip_server: &rsip::Uri, expires: Option<u32>) -> Result<u32> {
-        let mut registration = self.inner.registration.lock().await;
-        let resp = match registration
+    pub async fn do_register(
+        &mut self,
+        sip_server: &rsip::Uri,
+        expires: Option<u32>,
+        contact: &rsip::typed::Contact,
+    ) -> Result<(u32, Option<HostWithPort>)> {
+        self.registration.contact = Some(contact.clone());
+        let resp = match self
+            .registration
             .register(sip_server.clone(), expires)
             .await
             .map_err(|e| anyhow::anyhow!("Registration failed: {}", e))
@@ -73,16 +86,18 @@ impl RegistrationHandle {
                 return Err(anyhow::anyhow!("Registration failed: {}", e));
             }
         };
-
         debug!(
-            user = self.inner.option.aor(),
+            user = self.option.aor(),
             "registration response: {:?}", resp
         );
         match resp.status_code().kind() {
             StatusCodeKind::Successful => {
-                *self.inner.last_update.lock().await = Instant::now();
-                *self.inner.last_response.lock().await = Some(resp);
-                Ok(registration.expires())
+                self.last_update = Instant::now();
+                self.last_response = Some(resp);
+                Ok((
+                    self.registration.expires(),
+                    self.registration.public_address.clone(),
+                ))
             }
             _ => Err(anyhow::anyhow!("{:?}", resp.reason_phrase())),
         }


### PR DESCRIPTION
## Summary

- re-register when a public address is discovered and differs from the current contact address
- remove Mutex from RegistrationHandle
- fix the registration stuck bug at refresh time caused by sleeping inside the select register branch
- simplify learned-address handling so it only applies to UDP
