### PR TITLE
Fix auto_hangup not triggering for non-streaming TTS

### DIFF
--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -1045,7 +1045,7 @@ impl ActiveCall {
             speaker,
             play_id: play_id.clone(),
             streaming,
-            end_of_stream,
+            end_of_stream: if !streaming { true } else { end_of_stream },
             option: tts_option,
             base64,
             cache_key,


### PR DESCRIPTION
Closes #84
For non-streaming TTS, `end_of_stream` was never set, so the TTS task waited indefinitely for more commands and never exited. This prevented `TrackEnd` from firing, which meant `auto_hangup` never triggered.

Fix: force `end_of_stream=true` when `streaming=false` so the task exits cleanly after synthesis completes.