### PR TITLE
feat: Handle in-dialog SIP REFER with `TransferRequest` event

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -426,6 +426,16 @@ impl AppStateInner {
                     info!(?key, "ignoring out-of-dialog OPTIONS request");
                     continue;
                 }
+                rsipstack::rsip::Method::Refer => {
+                    info!(?key, "ignoring out-of-dialog REFER");
+                    match tx.reply(rsipstack::rsip::StatusCode::BadRequest).await {
+                        Ok(_) => (),
+                        Err(e) => {
+                            info!("error replying to out-of-dialog REFER: {:?}", e);
+                        }
+                    }
+                    continue;
+                }
                 _ => {
                     info!(?key, "received request: {:?}", tx.original.method);
                     match tx.reply(rsipstack::rsip::StatusCode::OK).await {

--- a/src/call/sip.rs
+++ b/src/call/sip.rs
@@ -398,6 +398,30 @@ impl DialogStateReceiverGuard {
                     info!(session_id = states.session_id, %dialog_id, "dialog options received");
                     tx_handle.reply(rsipstack::rsip::StatusCode::OK).await.ok();
                 }
+                DialogState::Refer(dialog_id, req, tx_handle) => {
+                    let refer_to = req.headers.iter().find_map(|h| {
+                        if let rsipstack::rsip::Header::ReferTo(h) = h {
+                            return Some(h.value().to_string());
+                        }
+                        None
+                    }).unwrap_or_default();
+                    let referred_by = req.headers.iter().find_map(|h| {
+                        if let rsipstack::rsip::Header::ReferredBy(h) = h {
+                            return Some(h.value().to_string());
+                        }
+                        None
+                    });
+                    info!(session_id = states.session_id, %dialog_id, %refer_to, "received REFER");
+                    tx_handle.reply(rsipstack::rsip::StatusCode::Other(202, "Accepted".into())).await.ok();
+                    let is_refer = states.call_state.read().await.is_refer;
+                    states.event_sender.send(crate::event::SessionEvent::TransferRequest {
+                        track_id: states.track_id.clone(),
+                        timestamp: crate::media::get_timestamp(),
+                        refer_to,
+                        referred_by,
+                        refer: Some(is_refer),
+                    }).ok();
+                }
                 DialogState::Terminated(dialog_id, reason) => {
                     info!(
                         session_id = states.session_id,

--- a/src/event.rs
+++ b/src/event.rs
@@ -126,6 +126,13 @@ pub enum SessionEvent {
         timestamp: u64,
         on_hold: bool,
     },
+    TransferRequest {
+        track_id: String,
+        timestamp: u64,
+        refer_to: String,
+        referred_by: Option<String>,
+        refer: Option<bool>,
+    },
     TrackStart {
         track_id: String,
         timestamp: u64,


### PR DESCRIPTION
Incoming in-dialog REFER is now accepted with 202 and emits a `TransferRequest` session event containing the `refer_to` URI and optional `referred_by`. The original call is left active — no NOTIFY is sent, so the UA holds the subscription open without auto-BYE-ing the call. Out-of-dialog REFER is rejected with 400.

Closes https://github.com/miuda-ai/active-call/issues/89
