### PR TITLE
fix: reject pre-answer SIP dialogs when handler exits

### DIFF
--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -1506,6 +1506,14 @@ impl ActiveCall {
     }
 
     pub async fn cleanup(&self) -> Result<()> {
+        if matches!(self.call_type, ActiveCallType::Sip | ActiveCallType::B2bua) {
+            self.do_reject(
+                Some(rsipstack::rsip::StatusCode::Decline),
+                Some("handler disconnected".to_string()),
+            )
+            .await
+            .ok();
+        }
         self.call_state.write().await.tts_handle = None;
         self.media_stream.cleanup().await.ok();
         Ok(())

--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -964,7 +964,22 @@ impl ActiveCall {
                 );
                 self.invitation.hangup(id, code, reason).await
             }
-            None => Ok(()),
+            None => {
+                let ready = self.call_state.write().await.ready_to_answer.take();
+                if let Some((_, _, dialog)) = ready {
+                    info!(
+                        session_id = self.session_id,
+                        ?reason,
+                        ?code,
+                        "rejecting call from ready_to_answer"
+                    );
+                    let dialog_id = dialog.id();
+                    dialog.reject(code, reason).ok();
+                    self.invitation.dialog_layer.remove_dialog(&dialog_id);
+                    self.cancel_token.cancel();
+                }
+                Ok(())
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- fix rejecting an incoming SIP call after `ringing` has already moved the dialog out of the pending-dialog map
- reject still-pending incoming dialogs during `ActiveCall::cleanup()` when the handler websocket exits before sending `ringing`, `accept`, or `reject`

## Root cause
Issue #88 had two related pre-answer paths.

The first was the `ringing` path. `do_ringing()` calls `invite_or_accept()`, which reaches `setup_caller_track()` and consumes the incoming SIP dialog from `pending_dialogs`. `prepare_incoming_sip_track()` then stores that dialog in `call_state.ready_to_answer`. Before `cfe2e28`, `do_reject()` only looked in `pending_dialogs`, so a later reject no longer found the dialog once `ringing` had run.

The second was the handler-disconnect path. The websocket side creates its own handler-local cancel token in `call_handler()`, while the pending-dialog timeout logic in `process_incoming_request()` uses a different token attached to the invite guard. When the websocket closed, it only canceled the handler-local token, so the pre-answer SIP dialog was not rejected. The normal active-call process loop is centered on media/answered-call teardown, and `ActiveCall::cleanup()` previously only cleaned local media state.

## What changed
- teach `do_reject()` to also reject from `ready_to_answer`
- call `do_reject(603 Decline, "handler disconnected")` from `ActiveCall::cleanup()` for SIP/B2BUA calls

Fixes #88.

## Validation
- `cargo check`
