### PR TITLE
fix: dynamic RTP payload type mapping for SIP re-INVITE and Opus PT negotiation

### DIFF
--- a/src/media/track/rtc.rs
+++ b/src/media/track/rtc.rs
@@ -429,9 +429,9 @@ impl RtcTrack {
         let packet_sender = packet_sender.lock().await;
         if let Some(sender) = packet_sender.as_ref() {
             let payload_type = frame.payload_type.unwrap_or(default_payload_type);
-            let src_codec = match CodecType::try_from(payload_type) {
-                Ok(c) => c,
-                Err(_) => {
+            let src_codec = match processor_chain.codec.get_codec_for_pt(payload_type) {
+                Some(c) => c,
+                None => {
                     debug!(track_id=%track_id, "Unknown payload type {}, skipping frame", payload_type);
                     return;
                 }
@@ -489,12 +489,7 @@ impl RtcTrack {
                     }
                     for fmt in &media.formats {
                         if let Ok(pt) = fmt.parse::<u8>() {
-                            let codec = self
-                                .encoder
-                                .payload_type_map
-                                .get(&pt)
-                                .cloned()
-                                .or_else(|| CodecType::try_from(pt).ok());
+                            let codec = self.encoder.get_codec_for_pt(pt);
                             if let Some(c) = codec {
                                 if c == *preferred_codec {
                                     negotiated = Some((pt, c));
@@ -513,13 +508,7 @@ impl RtcTrack {
             if negotiated.is_none() {
                 for fmt in &media.formats {
                     if let Ok(pt) = fmt.parse::<u8>() {
-                        let codec = self
-                            .encoder
-                            .payload_type_map
-                            .get(&pt)
-                            .cloned()
-                            .or_else(|| CodecType::try_from(pt).ok());
-
+                        let codec = self.encoder.get_codec_for_pt(pt);
                         if let Some(codec) = codec {
                             if codec != CodecType::TelephoneEvent {
                                 negotiated = Some((pt, codec));
@@ -747,10 +736,7 @@ impl Track for RtcTrack {
                     let (_, encoded) = self.encoder.encode(payload_type, packet.clone());
                     let target_codec = self
                         .encoder
-                        .payload_type_map
-                        .get(&payload_type)
-                        .cloned()
-                        .or_else(|| CodecType::try_from(payload_type).ok())
+                        .get_codec_for_pt(payload_type)
                         .ok_or_else(|| anyhow::anyhow!("Invalid codec type: {}", payload_type))?;
                     if !encoded.is_empty() {
                         let clock_rate = target_codec.clock_rate();
@@ -802,10 +788,7 @@ impl Track for RtcTrack {
                 } => {
                     let target_codec = self
                         .encoder
-                        .payload_type_map
-                        .get(payload_type)
-                        .cloned()
-                        .or_else(|| CodecType::try_from(*payload_type).ok())
+                        .get_codec_for_pt(*payload_type)
                         .ok_or_else(|| anyhow::anyhow!("Invalid codec type: {}", payload_type))?;
                     let clock_rate = target_codec.clock_rate();
 

--- a/src/media/track/track_codec.rs
+++ b/src/media/track/track_codec.rs
@@ -7,6 +7,7 @@ use audio_codec::{
     samples_to_bytes,
 };
 use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
 
 use audio_codec::g729::{G729Decoder, G729Encoder};
 #[cfg(feature = "opus")]
@@ -32,27 +33,29 @@ pub struct TrackCodec {
     resampler: Option<Resampler>,
     resampler_in_rate: u32,
     resampler_out_rate: u32,
-    pub payload_type_map: HashMap<u8, CodecType>,
+    pub payload_type_map: Arc<RwLock<HashMap<u8, CodecType>>>,
 }
 
 impl Clone for TrackCodec {
     fn clone(&self) -> Self {
         let mut new = Self::new();
-        new.payload_type_map = self.payload_type_map.clone();
+        // Share the same underlying map so reinvite PT updates are visible to all clones.
+        new.payload_type_map = Arc::clone(&self.payload_type_map);
         new
     }
 }
 
 impl TrackCodec {
     pub fn new() -> Self {
-        let mut payload_type_map = HashMap::new();
-        payload_type_map.insert(0, CodecType::PCMU);
-        payload_type_map.insert(8, CodecType::PCMA);
-        payload_type_map.insert(9, CodecType::G722);
-        payload_type_map.insert(18, CodecType::G729);
-        payload_type_map.insert(101, CodecType::TelephoneEvent);
+        let mut map = HashMap::new();
+        map.insert(0, CodecType::PCMU);
+        map.insert(8, CodecType::PCMA);
+        map.insert(9, CodecType::G722);
+        map.insert(18, CodecType::G729);
+        map.insert(101, CodecType::TelephoneEvent);
         #[cfg(feature = "opus")]
-        payload_type_map.insert(111, CodecType::Opus);
+        map.insert(111, CodecType::Opus);
+        let payload_type_map = Arc::new(RwLock::new(map));
 
         Self {
             pcmu_encoder: PcmuEncoder::new(),
@@ -75,7 +78,18 @@ impl TrackCodec {
     }
 
     pub fn set_payload_type(&mut self, pt: u8, codec: CodecType) {
-        self.payload_type_map.insert(pt, codec);
+        self.payload_type_map.write().unwrap().insert(pt, codec);
+    }
+
+    /// Look up the codec for a given RTP payload type, consulting the negotiated map first
+    /// and falling back to the static payload type registry.
+    pub fn get_codec_for_pt(&self, pt: u8) -> Option<CodecType> {
+        self.payload_type_map
+            .read()
+            .unwrap()
+            .get(&pt)
+            .cloned()
+            .or_else(|| CodecType::try_from(pt).ok())
     }
 
     pub fn is_audio(payload_type: u8) -> bool {
@@ -95,6 +109,8 @@ impl TrackCodec {
     ) -> (u32, u16, PcmBuf) {
         let codec = self
             .payload_type_map
+            .read()
+            .unwrap()
             .get(&payload_type)
             .cloned()
             .unwrap_or_else(|| match payload_type {
@@ -170,6 +186,8 @@ impl TrackCodec {
             Samples::PCM { samples: mut pcm } => {
                 let codec = self
                     .payload_type_map
+                    .read()
+                    .unwrap()
                     .get(&payload_type)
                     .cloned()
                     .or_else(|| CodecType::try_from(payload_type).ok());


### PR DESCRIPTION
Closes https://github.com/miuda-ai/active-call/issues/92

Written by claude, I've verified the code and that it fixes the issue.


Problem

When a SIP client offers a dynamic payload type for Opus (e.g. PT 96), the server correctly negotiates it via SDP, but incoming RTP frames were dropped with:

```
Unknown payload type 96, skipping frame
```

Two bugs caused this:

**1. `process_audio_frame` ignored the negotiated PT map.**
The receive loop resolved codec identity via `CodecType::try_from(payload_type)`, which only knows about statically-registered PTs (0, 8, 9, 18, 111…). Dynamic PTs in the 96–127 range that were negotiated via SDP were never resolvable here, so every frame was silently dropped.

**2. `payload_type_map` was deep-copied at worker spawn time, making re-INVITE updates invisible.**
`TrackCodec::clone()` copied the `HashMap`, so when `parse_sdp_payload_types` wrote new PT→codec mappings during a re-INVITE, the running worker's separate copy never saw those updates.

### Fix

- **`TrackCodec.payload_type_map`** is now `Arc<RwLock<HashMap<u8, CodecType>>>`. `Clone` clones the `Arc` (shared reference) instead of the `HashMap`, so all worker copies and the `RtcTrack` struct share the same live map. Any write from `set_payload_type` (called during SDP negotiation) is immediately visible to all workers.

- **Added `TrackCodec::get_codec_for_pt(pt)`** — checks the shared map first, falls back to the static `CodecType::try_from` registry. Used consistently everywhere a PT→codec lookup was needed.

- **`process_audio_frame`** now uses `processor_chain.codec.get_codec_for_pt(payload_type)` instead of `CodecType::try_from`, so dynamically negotiated PTs (e.g. PT 96 = Opus) are resolved correctly on every frame.

- All other direct `payload_type_map` field accesses in `rtc.rs` (`parse_sdp_payload_types`, `send_packet`) replaced with `get_codec_for_pt`.

### Affected files

- `src/media/track/track_codec.rs` — shared map, new `get_codec_for_pt` method
- `src/media/track/rtc.rs` — fix receive loop lookup, consolidate all PT resolution through `get_codec_for_pt