### PR TITLE
feat: Add `offset_ms` to Play command for seeking into audio files

### DIFF
--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -732,8 +732,9 @@ impl ActiveCall {
                 play_id,
                 auto_hangup,
                 wait_input_timeout,
+                offset_ms,
             } => {
-                self.do_play(url, play_id, auto_hangup, wait_input_timeout)
+                self.do_play(url, play_id, auto_hangup, wait_input_timeout, offset_ms)
                     .await
             }
             Command::Hangup {
@@ -1016,7 +1017,7 @@ impl ActiveCall {
             );
             if let Some(ringtone_url) = ringtone {
                 drop(state);
-                self.do_play(ringtone_url, None, None, None).await.ok();
+                self.do_play(ringtone_url, None, None, None, None).await.ok();
             } else {
                 info!(session_id = self.session_id, "no ringtone to play");
             }
@@ -1160,6 +1161,7 @@ impl ActiveCall {
         play_id: Option<String>,
         auto_hangup: Option<bool>,
         wait_input_timeout: Option<u32>,
+        offset_ms: Option<u32>,
     ) -> Result<()> {
         let ssrc = rand::random::<u32>();
         info!(
@@ -1169,11 +1171,15 @@ impl ActiveCall {
 
         let play_id = play_id.or(Some(url.clone()));
 
-        let file_track = FileTrack::new(self.server_side_track_id.clone())
+        let mut file_track = FileTrack::new(self.server_side_track_id.clone())
             .with_play_id(play_id.clone())
             .with_ssrc(ssrc)
             .with_path(url)
             .with_cancel_token(self.cancel_token.child_token());
+
+        if let Some(offset) = offset_ms {
+            file_track = file_track.with_offset_ms(offset);
+        }
 
         {
             let mut state = self.call_state.write().await;

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -64,6 +64,7 @@ pub enum Command {
         play_id: Option<String>,
         auto_hangup: Option<bool>,
         wait_input_timeout: Option<u32>,
+        offset_ms: Option<u32>,
     },
     Interrupt {
         graceful: Option<bool>,

--- a/src/media/track/file.rs
+++ b/src/media/track/file.rs
@@ -309,6 +309,7 @@ pub struct FileTrack {
     path: Option<String>,
     use_cache: bool,
     ssrc: u32,
+    offset_ms: u32,
 }
 
 impl FileTrack {
@@ -323,6 +324,7 @@ impl FileTrack {
             path: None,
             use_cache: true,
             ssrc: 0,
+            offset_ms: 0,
         }
     }
 
@@ -362,6 +364,11 @@ impl FileTrack {
 
     pub fn with_cache_enabled(mut self, use_cache: bool) -> Self {
         self.use_cache = use_cache;
+        self
+    }
+
+    pub fn with_offset_ms(mut self, offset_ms: u32) -> Self {
+        self.offset_ms = offset_ms;
         self
     }
 }
@@ -405,6 +412,7 @@ impl Track for FileTrack {
         let token = self.cancel_token.clone();
         let start_time = crate::media::get_timestamp();
         let ssrc = self.ssrc;
+        let offset_ms = self.offset_ms;
         // Spawn async task to handle file streaming
         let play_id = self.play_id.clone();
         crate::spawn(async move {
@@ -473,6 +481,7 @@ impl Track for FileTrack {
                     &id,
                     sample_rate,
                     packet_duration_ms,
+                    offset_ms,
                     token,
                     packet_sender,
                 )
@@ -537,11 +546,12 @@ async fn stream_audio_file(
     track_id: &str,
     target_sample_rate: u32,
     packet_duration_ms: u32,
+    offset_ms: u32,
     token: CancellationToken,
     packet_sender: TrackPacketSender,
 ) -> Result<()> {
     let start_time = Instant::now();
-    let audio_reader = match extension {
+    let mut audio_reader = match extension {
         "wav" => {
             // Use spawn_blocking for CPU-intensive WAV decoding
             let reader = tokio::task::spawn_blocking(move || {
@@ -566,6 +576,11 @@ async fn stream_audio_file(
         audio_reader.sample_rate(),
         extension
     );
+    if offset_ms > 0 {
+        let offset_samples =
+            (offset_ms as usize * audio_reader.sample_rate() as usize) / 1000;
+        audio_reader.set_position(offset_samples.min(audio_reader.buffer_size()));
+    }
     process_audio_reader(
         processor_chain,
         audio_reader,

--- a/src/playbook/handler/mod.rs
+++ b/src/playbook/handler/mod.rs
@@ -695,6 +695,7 @@ impl LlmHandler {
                     play_id: None,
                     auto_hangup: None,
                     wait_input_timeout: None,
+                    offset_ms: None,
                 });
             }
 
@@ -1098,6 +1099,7 @@ impl LlmHandler {
                             play_id: None,
                             auto_hangup: None,
                             wait_input_timeout: None,
+                            offset_ms: None,
                         });
                         buffer.drain(..mat.end());
                     }
@@ -1905,6 +1907,7 @@ impl DialogueHandler for LlmHandler {
                         play_id: None,
                         auto_hangup: None,
                         wait_input_timeout: None,
+                        offset_ms: None,
                     });
                 }
             }


### PR DESCRIPTION
Adds an optional `offset_ms: Option<u32>` field to the `Play` command, allowing callers to skip the first N milliseconds of a file before playback begins.

The offset is applied after decoding by advancing the `AudioReader` position to `offset_ms * sample_rate / 1000` samples, clamped to the buffer length. Both WAV and MP3 readers are supported since both decode the entire file upfront at the target sample rate.

No behavior change when `offset_ms` is `None` or `0`.

Made this to work around #87, because it requires a greater refactor for mixing. But this functionality is useful in itself.