### PR TITLE
feat: add OGG/Opus support for Play and unify audio decoding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,7 @@ knf-rs-sys = { version = "0.3.2", optional = true }
 
 # Audio processing
 symphonia = { version = "0.5", features = ["all"] }
+ogg = "0.9"
 unicode-normalization = "0.1"
 rand_distr = "0.6.0"
 num_cpus = "1.16"

--- a/src/media/loader.rs
+++ b/src/media/loader.rs
@@ -1,10 +1,13 @@
 use crate::media::cache;
 use anyhow::{Result, anyhow};
 use audio_codec::Resampler;
+use audio_codec::opus::OpusDecoder;
 use hound::WavReader;
+use ogg::reading::PacketReader;
 use reqwest::Client;
 use std::fs::File;
 use std::io::{BufReader, Seek, SeekFrom, Write};
+use std::time::Instant;
 use symphonia::core::audio::SampleBuffer;
 use symphonia::core::codecs::DecoderOptions;
 use symphonia::core::errors::Error as SymphoniaError;
@@ -13,16 +16,14 @@ use symphonia::core::io::MediaSourceStream;
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
 use symphonia::default::{get_codecs, get_probe};
-use std::time::Instant;
 use tracing::{info, warn};
 use url::Url;
 
-pub async fn download_from_url(url: &str, use_cache: bool) -> Result<File> {
-    // Check if file is already cached
+pub async fn download_from_url(url: &str, use_cache: bool) -> Result<(File, Option<String>)> {
     let cache_key = cache::generate_cache_key(url, 0, None, None);
     if use_cache && cache::is_cached(&cache_key).await? {
         match cache::get_cache_path(&cache_key) {
-            Ok(path) => return File::open(&path).map_err(|e| anyhow!(e)),
+            Ok(path) => return Ok((File::open(&path).map_err(|e| anyhow!(e))?, None)),
             Err(e) => {
                 warn!("loader: Error getting cache path: {}", e);
                 return Err(e);
@@ -30,26 +31,30 @@ pub async fn download_from_url(url: &str, use_cache: bool) -> Result<File> {
         }
     }
 
-    // Download file if not cached
     let start_time = Instant::now();
     let client = Client::new();
     let response = client.get(url).send().await?;
+    let content_type = response
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .map(|s| s.split(';').next().unwrap_or(s).trim().to_string());
     let bytes = response.bytes().await?;
     let data = bytes.to_vec();
     let duration = start_time.elapsed();
 
     info!(
-        "loader: Downloaded {} bytes in {:?} for {}",
+        "loader: Downloaded {} bytes in {:?} for {} (content-type: {:?})",
         data.len(),
         duration,
         url,
+        content_type,
     );
 
-    // Store in cache if enabled
     if use_cache {
         cache::store_in_cache(&cache_key, &data).await?;
         match cache::get_cache_path(&cache_key) {
-            Ok(path) => return File::open(path).map_err(|e| anyhow!(e)),
+            Ok(path) => return Ok((File::open(path).map_err(|e| anyhow!(e))?, content_type)),
             Err(e) => {
                 warn!("loader: Error getting cache path: {}", e);
                 return Err(e);
@@ -57,11 +62,93 @@ pub async fn download_from_url(url: &str, use_cache: bool) -> Result<File> {
         }
     }
 
-    // Return temporary file with downloaded data
     let mut temp_file = tempfile::tempfile()?;
     temp_file.write_all(&data)?;
     temp_file.seek(SeekFrom::Start(0))?;
-    Ok(temp_file)
+    Ok((temp_file, content_type))
+}
+
+fn is_ogg(extension: &str, mime_type: Option<&str>) -> bool {
+    matches!(extension, "ogg" | "opus")
+        || matches!(
+            mime_type,
+            Some("audio/ogg") | Some("audio/opus") | Some("application/ogg")
+        )
+}
+
+enum OggCodec {
+    Opus { channels: u16 },
+    Other,
+}
+
+fn detect_ogg_codec(file: &mut File) -> Result<OggCodec> {
+    let mut reader = PacketReader::new(BufReader::new(&mut *file));
+    let head = reader
+        .read_packet_expected()
+        .map_err(|e| anyhow!("loader: failed reading OGG header: {e}"))?;
+    let codec = if head.data.starts_with(b"OpusHead") {
+        let channels = if head.data.len() > 9 {
+            head.data[9] as u16
+        } else {
+            2
+        };
+        OggCodec::Opus { channels }
+    } else {
+        OggCodec::Other
+    };
+    file.seek(SeekFrom::Start(0))?;
+    Ok(codec)
+}
+
+fn decode_opus_ogg(file: File, channels: u16, target_sample_rate: u32) -> Result<Vec<i16>> {
+    let mut reader = PacketReader::new(BufReader::new(file));
+
+    // Consume OpusHead (already peeked, but file was seeked back)
+    let head = reader
+        .read_packet_expected()
+        .map_err(|e| anyhow!("loader: failed reading OGG header: {e}"))?;
+    let channels = if head.data.len() > 9 {
+        head.data[9] as u16
+    } else {
+        channels
+    };
+
+    // Skip OpusTags packet
+    reader
+        .read_packet_expected()
+        .map_err(|e| anyhow!("loader: failed reading OpusTags: {e}"))?;
+
+    // Opus always encodes at 48 kHz; decode there and resample afterwards
+    let mut decoder = OpusDecoder::new(48000, channels);
+    let mut all_samples: Vec<i16> = Vec::new();
+
+    loop {
+        let packet = match reader.read_packet() {
+            Ok(Some(p)) => p,
+            Ok(None) => break,
+            Err(e) => return Err(anyhow!("loader: failed reading OGG packet: {e}")),
+        };
+        let samples = audio_codec::Decoder::decode(&mut decoder, &packet.data);
+        all_samples.extend_from_slice(&samples);
+    }
+
+    if all_samples.is_empty() {
+        return Err(anyhow!(
+            "loader: no decodable audio samples found in Opus stream"
+        ));
+    }
+
+    info!(
+        "loader: decoded Opus stream at 48000 Hz, {} channel(s)",
+        channels
+    );
+
+    if target_sample_rate != 48000 {
+        let mut resampler = Resampler::new(48000, target_sample_rate as usize);
+        all_samples = resampler.resample(&all_samples);
+    }
+
+    Ok(all_samples)
 }
 
 pub fn decode_wav(file: File, target_sample_rate: u32) -> Result<Vec<i16>> {
@@ -149,10 +236,38 @@ pub fn decode_wav(file: File, target_sample_rate: u32) -> Result<Vec<i16>> {
     Ok(all_samples)
 }
 
-pub fn decode_mp3(file: File, target_sample_rate: u32) -> Result<Vec<i16>> {
+pub fn decode_audio(
+    mut file: File,
+    extension: &str,
+    mime_type: Option<&str>,
+    target_sample_rate: u32,
+) -> Result<Vec<i16>> {
+    if matches!(extension, "wav")
+        || matches!(
+            mime_type,
+            Some("audio/wav") | Some("audio/wave") | Some("audio/x-wav")
+        )
+    {
+        return decode_wav(file, target_sample_rate);
+    }
+
+    if is_ogg(extension, mime_type) {
+        match detect_ogg_codec(&mut file)? {
+            OggCodec::Opus { channels } => {
+                return decode_opus_ogg(file, channels, target_sample_rate);
+            }
+            OggCodec::Other => {} // fall through to symphonia (e.g. Vorbis)
+        }
+    }
+
     let mss = MediaSourceStream::new(Box::new(file), Default::default());
     let mut hint = Hint::new();
-    hint.with_extension("mp3");
+    if !extension.is_empty() {
+        hint.with_extension(extension);
+    }
+    if let Some(mime) = mime_type {
+        hint.mime_type(mime);
+    }
 
     let probed = get_probe().format(
         &hint,
@@ -165,7 +280,7 @@ pub fn decode_mp3(file: File, target_sample_rate: u32) -> Result<Vec<i16>> {
     let (track_id, codec_params) = {
         let track = format
             .default_track()
-            .ok_or_else(|| anyhow!("loader: no default audio track found in mp3"))?;
+            .ok_or_else(|| anyhow!("loader: no default audio track found"))?;
         (track.id, track.codec_params.clone())
     };
 
@@ -178,7 +293,7 @@ pub fn decode_mp3(file: File, target_sample_rate: u32) -> Result<Vec<i16>> {
             Ok(packet) => packet,
             Err(SymphoniaError::IoError(_)) => break,
             Err(SymphoniaError::ResetRequired) => continue,
-            Err(e) => return Err(anyhow!("loader: failed reading mp3 packet: {e}")),
+            Err(e) => return Err(anyhow!("loader: failed reading audio packet: {e}")),
         };
 
         if packet.track_id() != track_id {
@@ -189,7 +304,12 @@ pub fn decode_mp3(file: File, target_sample_rate: u32) -> Result<Vec<i16>> {
             Ok(decoded) => {
                 if sample_rate == 0 {
                     sample_rate = decoded.spec().rate;
-                    info!("MP3 file detected with sample rate: {} Hz", sample_rate);
+                    info!(
+                        "loader: detected {:?} with sample rate: {} Hz, channels: {}",
+                        codec_params.codec,
+                        sample_rate,
+                        decoded.spec().channels.count()
+                    );
                 }
                 let spec = *decoded.spec();
                 let channels = spec.channels.count();
@@ -213,12 +333,12 @@ pub fn decode_mp3(file: File, target_sample_rate: u32) -> Result<Vec<i16>> {
             Err(SymphoniaError::DecodeError(_)) => continue,
             Err(SymphoniaError::IoError(_)) => break,
             Err(SymphoniaError::ResetRequired) => continue,
-            Err(e) => return Err(anyhow!("loader: failed decoding mp3 packet: {e}")),
+            Err(e) => return Err(anyhow!("loader: failed decoding audio packet: {e}")),
         }
     }
 
     if all_samples.is_empty() {
-        return Err(anyhow!("loader: no decodable audio samples found in mp3"));
+        return Err(anyhow!("loader: no decodable audio samples found"));
     }
 
     if sample_rate != target_sample_rate && sample_rate > 0 {
@@ -234,26 +354,24 @@ pub async fn load_audio_as_pcm(
     target_sample_rate: u32,
     use_cache: bool,
 ) -> Result<Vec<i16>> {
-    let extension = if path.starts_with("http://") || path.starts_with("https://") {
-        path.parse::<Url>()?
-            .path()
-            .split(".")
-            .last()
-            .unwrap_or("")
-            .to_string()
+    let is_url = path.starts_with("http://") || path.starts_with("https://");
+
+    let (file, content_type) = if is_url {
+        download_from_url(path, use_cache).await?
+    } else {
+        (File::open(path).map_err(|e| anyhow!("loader: {} {}", path, e))?, None)
+    };
+
+    let extension = if is_url {
+        path.parse::<Url>()?.path().split('.').last().unwrap_or("").to_string()
     } else {
         path.split('.').last().unwrap_or("").to_string()
     };
 
-    let file = if path.starts_with("http://") || path.starts_with("https://") {
-        download_from_url(path, use_cache).await?
-    } else {
-        File::open(path).map_err(|e| anyhow!("loader: {} {}", path, e))?
-    };
-
-    match extension.to_lowercase().as_str() {
-        "wav" => decode_wav(file, target_sample_rate),
-        "mp3" => decode_mp3(file, target_sample_rate),
-        _ => Err(anyhow!("loader: Unsupported file extension: {}", extension)),
-    }
+    decode_audio(
+        file,
+        &extension,
+        content_type.as_deref(),
+        target_sample_rate,
+    )
 }

--- a/src/media/track/file.rs
+++ b/src/media/track/file.rs
@@ -72,7 +72,7 @@ trait AudioReader: Send {
     fn resample_chunk(&mut self, chunk: &[i16]) -> Vec<i16>;
 }
 
-struct WavAudioReader {
+struct DecodedAudioReader {
     buffer: Vec<i16>,
     sample_rate: u32,
     position: usize,
@@ -80,9 +80,15 @@ struct WavAudioReader {
     resampler: Option<Resampler>,
 }
 
-impl WavAudioReader {
-    fn from_file(file: File, target_sample_rate: u32) -> Result<Self> {
-        let all_samples = crate::media::loader::decode_wav(file, target_sample_rate)?;
+impl DecodedAudioReader {
+    fn from_file(
+        file: File,
+        extension: &str,
+        mime_type: Option<&str>,
+        target_sample_rate: u32,
+    ) -> Result<Self> {
+        let all_samples =
+            crate::media::loader::decode_audio(file, extension, mime_type, target_sample_rate)?;
         Ok(Self {
             buffer: all_samples,
             sample_rate: target_sample_rate,
@@ -91,108 +97,14 @@ impl WavAudioReader {
             resampler: None,
         })
     }
+}
 
+impl AudioReader for DecodedAudioReader {
     fn fill_buffer(&mut self) -> Result<usize> {
-        // All data is already decoded and stored in buffer
-        // Return the remaining samples from current position
         if self.position >= self.buffer.len() {
-            return Ok(0); // End of file
+            return Ok(0);
         }
-
-        let remaining = self.buffer.len() - self.position;
-        Ok(remaining)
-    }
-}
-
-impl AudioReader for WavAudioReader {
-    fn fill_buffer(&mut self) -> Result<usize> {
-        // This method is already implemented in the WavAudioReader struct
-        // We just call it here
-        WavAudioReader::fill_buffer(self)
-    }
-
-    fn buffer_size(&self) -> usize {
-        self.buffer.len()
-    }
-
-    fn position(&self) -> usize {
-        self.position
-    }
-
-    fn set_position(&mut self, pos: usize) {
-        self.position = pos;
-    }
-
-    fn sample_rate(&self) -> u32 {
-        self.sample_rate
-    }
-
-    fn target_sample_rate(&self) -> u32 {
-        self.target_sample_rate
-    }
-
-    fn channels(&self) -> u16 {
-        1
-    }
-
-    fn extract_chunk(&self, start: usize, end: usize) -> Vec<i16> {
-        self.buffer[start..end].to_vec()
-    }
-
-    fn resample_chunk(&mut self, chunk: &[i16]) -> Vec<i16> {
-        if self.sample_rate == self.target_sample_rate {
-            return chunk.to_vec();
-        }
-
-        if let Some(resampler) = &mut self.resampler {
-            resampler.resample(chunk)
-        } else {
-            let mut new_resampler =
-                Resampler::new(self.sample_rate as usize, self.target_sample_rate as usize);
-            let result = new_resampler.resample(chunk);
-            self.resampler = Some(new_resampler);
-            result
-        }
-    }
-}
-
-struct Mp3AudioReader {
-    buffer: Vec<i16>,
-    sample_rate: u32,
-    position: usize,
-    target_sample_rate: u32,
-    resampler: Option<Resampler>,
-}
-
-impl Mp3AudioReader {
-    fn from_file(file: File, target_sample_rate: u32) -> Result<Self> {
-        let all_samples = crate::media::loader::decode_mp3(file, target_sample_rate)?;
-        Ok(Self {
-            buffer: all_samples,
-            sample_rate: target_sample_rate,
-            position: 0,
-            target_sample_rate,
-            resampler: None,
-        })
-    }
-
-    fn fill_buffer(&mut self) -> Result<usize> {
-        // All data is already decoded and stored in buffer
-        // Return the remaining samples from current position
-        if self.position >= self.buffer.len() {
-            return Ok(0); // End of file
-        }
-
-        let remaining = self.buffer.len() - self.position;
-        Ok(remaining)
-    }
-}
-
-impl AudioReader for Mp3AudioReader {
-    fn fill_buffer(&mut self) -> Result<usize> {
-        // This method is already implemented in the Mp3AudioReader struct
-        // We just call it here
-        Mp3AudioReader::fill_buffer(self)
+        Ok(self.buffer.len() - self.position)
     }
 
     fn buffer_size(&self) -> usize {
@@ -231,7 +143,6 @@ impl AudioReader for Mp3AudioReader {
         if let Some(resampler) = &mut self.resampler {
             resampler.resample(chunk)
         } else {
-            // Initialize resampler if needed
             let mut new_resampler =
                 Resampler::new(self.sample_rate as usize, self.target_sample_rate as usize);
             let result = new_resampler.resample(chunk);
@@ -409,33 +320,30 @@ impl Track for FileTrack {
         let play_id = self.play_id.clone();
         crate::spawn(async move {
             let res = async move {
-                // Determine file extension
-                let extension = if path.starts_with("http://") || path.starts_with("https://") {
-                    path.parse::<Url>()?
-                        .path()
-                        .split(".")
-                        .last()
-                        .unwrap_or("")
-                        .to_string()
+                let is_url = path.starts_with("http://") || path.starts_with("https://");
+
+                let extension = if is_url {
+                    path.parse::<Url>()?.path().split('.').last().unwrap_or("").to_string()
                 } else {
                     path.split('.').last().unwrap_or("").to_string()
                 };
 
-                let cache_key = if path.starts_with("http://") || path.starts_with("https://") {
+                let cache_key = if is_url {
                     Some(cache::generate_cache_key(&path, 0, None, None))
                 } else {
                     None
                 };
 
                 // Open file or download from URL
-                let file = if path.starts_with("http://") || path.starts_with("https://") {
+                let open_result = if is_url {
                     crate::media::loader::download_from_url(&path, use_cache).await
                 } else {
-                    File::open(&path).map_err(|e| anyhow::anyhow!("filetrack: {}", e))
+                    File::open(&path)
+                        .map(|f| (f, None))
+                        .map_err(|e| anyhow::anyhow!("filetrack: {}", e))
                 };
-
-                let file = match file {
-                    Ok(file) => file,
+                let (file, content_type) = match open_result {
+                    Ok(result) => result,
                     Err(e) => {
                         warn!("filetrack: Error opening file: {}", e);
                         if let Some(key) = cache_key {
@@ -469,6 +377,7 @@ impl Track for FileTrack {
                 let stream_result = stream_audio_file(
                     processor_chain,
                     extension.as_str(),
+                    content_type.as_deref(),
                     file,
                     &id,
                     sample_rate,
@@ -533,6 +442,7 @@ impl Track for FileTrack {
 async fn stream_audio_file(
     processor_chain: ProcessorChain,
     extension: &str,
+    content_type: Option<&str>,
     file: File,
     track_id: &str,
     target_sample_rate: u32,
@@ -541,25 +451,18 @@ async fn stream_audio_file(
     packet_sender: TrackPacketSender,
 ) -> Result<()> {
     let start_time = Instant::now();
-    let audio_reader = match extension {
-        "wav" => {
-            // Use spawn_blocking for CPU-intensive WAV decoding
-            let reader = tokio::task::spawn_blocking(move || {
-                WavAudioReader::from_file(file, target_sample_rate)
-            })
-            .await??;
-            Box::new(reader) as Box<dyn AudioReader>
-        }
-        "mp3" => {
-            // Use spawn_blocking for CPU-intensive MP3 decoding
-            let reader = tokio::task::spawn_blocking(move || {
-                Mp3AudioReader::from_file(file, target_sample_rate)
-            })
-            .await??;
-            Box::new(reader) as Box<dyn AudioReader>
-        }
-        _ => return Err(anyhow!("Unsupported audio format: {}", extension)),
-    };
+    let extension_owned = extension.to_string();
+    let content_type_owned = content_type.map(|s| s.to_string());
+    let reader = tokio::task::spawn_blocking(move || {
+        DecodedAudioReader::from_file(
+            file,
+            &extension_owned,
+            content_type_owned.as_deref(),
+            target_sample_rate,
+        )
+    })
+    .await??;
+    let audio_reader = Box::new(reader) as Box<dyn AudioReader>;
     info!(
         "filetrack: Load file duration: {:.2} seconds, sample rate: {} Hz, extension: {}",
         start_time.elapsed().as_secs_f64(),
@@ -638,7 +541,7 @@ mod tests {
     async fn test_wav_reader() -> Result<()> {
         let file_path = "fixtures/sample.wav";
         let file = File::open(file_path)?;
-        let mut reader = WavAudioReader::from_file(file, 16000)?;
+        let mut reader = DecodedAudioReader::from_file(file, "wav", None, 16000)?;
         let mut total_samples = 0;
         let mut total_duration_ms = 0.0;
         let mut chunk_count = 0;
@@ -679,8 +582,7 @@ mod tests {
         }
         println!("Verified total samples: {}", verify_samples.len());
 
-        // Test using WavAudioReader
-        let mut reader = WavAudioReader::from_file(file, 16000)?;
+        let mut reader = DecodedAudioReader::from_file(file, "wav", None, 16000)?;
         let mut total_samples = 0;
         let mut total_duration_ms = 0.0;
         let mut chunk_count = 0;
@@ -810,7 +712,7 @@ mod tests {
         let file_path = "fixtures/sample.mp3".to_string();
         match File::open(&file_path) {
             Ok(file) => {
-                let samples = crate::media::loader::decode_mp3(file, 16000)?;
+                let samples = crate::media::loader::decode_audio(file, "mp3", None, 16000)?;
                 assert!(
                     !samples.is_empty(),
                     "Decoded sample list should not be empty"
@@ -831,8 +733,7 @@ mod tests {
         let file_path = "fixtures/sample.mp3".to_string();
         let file = File::open(&file_path)?;
         let sample_rate = 16000;
-        // Test directly creating and using a Mp3AudioReader
-        let mut reader = Mp3AudioReader::from_file(file, sample_rate)?;
+        let mut reader = DecodedAudioReader::from_file(file, "mp3", None, sample_rate)?;
         let mut total_samples = 0;
         let mut total_duration_ms = 0.0;
         while let Some((chunk, _chunk_sample_rate)) = reader.read_chunk(320)? {
@@ -862,7 +763,7 @@ mod tests {
         let output_path = "target/tmp/sample_16k_mono_s16le.pcm";
 
         let file = File::open(input_path)?;
-        let mut reader = Mp3AudioReader::from_file(file, 16000)?;
+        let mut reader = DecodedAudioReader::from_file(file, "mp3", None, 16000)?;
 
         let mut pcm_samples = Vec::<i16>::new();
         while let Some((chunk, _chunk_sample_rate)) = reader.read_chunk(320)? {


### PR DESCRIPTION
- Added OGG/Opus decoding via `ogg` crate (container demux) + `audio-codec` `OpusDecoder`, since symphonia has no built-in Opus codec
- Unified audio routing in `decode_audio`: WAV → hound, `audio/opus` or `.opus` extension → Opus decoder directly, `.ogg` / `audio/ogg` → probe first OGG packet to distinguish Opus from Vorbis (Vorbis falls through to symphonia), everything else → symphonia
- Extracted `download_from_url` content-type and passed it as a hint alongside the file extension, so format detection works correctly for URL downloads regardless of filename
- Collapsed `WavAudioReader` and `Mp3AudioReader` in `file.rs` into a single `DecodedAudioReader