### PR TITLE
feat: propagate `refer` flag through ASR and VAD events

### DIFF
--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -460,6 +460,7 @@ impl ActiveCall {
                 if expire > 0 && crate::media::get_timestamp() >= start_time + expire as u64 {
                     info!(session_id = self.session_id, "wait input timeout reached");
                     *input_timeout_expire.lock().await = (0, 0);
+                    let is_refer = self.call_state.read().await.is_refer;
                     event_sender
                         .send(SessionEvent::Silence {
                             track_id: self.server_side_track_id.clone(),
@@ -467,6 +468,7 @@ impl ActiveCall {
                             start_time,
                             duration: expire as u64,
                             samples: None,
+                            refer: Some(is_refer),
                         })
                         .ok();
                 }
@@ -1358,8 +1360,20 @@ impl ActiveCall {
             caller: Some(caller),
             callee: Some(callee.clone()),
             sip: refer_option.as_ref().and_then(|o| o.sip.clone()),
-            vad: refer_option.as_ref().and_then(|o| o.vad.clone()),
-            asr: refer_option.as_ref().and_then(|o| o.asr.clone()),
+            vad: refer_option
+                .as_ref()
+                .and_then(|o| o.vad.clone())
+                .map(|mut opts| {
+                    opts.refer = Some(true);
+                    opts
+                }),
+            asr: refer_option
+                .as_ref()
+                .and_then(|o| o.asr.clone())
+                .map(|mut opts| {
+                    opts.refer = Some(true);
+                    opts
+                }),
             denoise: refer_option.as_ref().and_then(|o| o.denoise.clone()),
             recorder,
             ..Default::default()

--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -1017,7 +1017,9 @@ impl ActiveCall {
             );
             if let Some(ringtone_url) = ringtone {
                 drop(state);
-                self.do_play(ringtone_url, None, None, None, None).await.ok();
+                self.do_play(ringtone_url, None, None, None, None)
+                    .await
+                    .ok();
             } else {
                 info!(session_id = self.session_id, "no ringtone to play");
             }
@@ -1356,6 +1358,7 @@ impl ActiveCall {
             caller: Some(caller),
             callee: Some(callee.clone()),
             sip: refer_option.as_ref().and_then(|o| o.sip.clone()),
+            vad: refer_option.as_ref().and_then(|o| o.vad.clone()),
             asr: refer_option.as_ref().and_then(|o| o.asr.clone()),
             denoise: refer_option.as_ref().and_then(|o| o.denoise.clone()),
             recorder,

--- a/src/event.rs
+++ b/src/event.rs
@@ -94,12 +94,14 @@ pub enum SessionEvent {
         start_time: u64,
         is_filler: Option<bool>,
         confidence: Option<f32>,
+        refer: Option<bool>,
     },
     Silence {
         track_id: String,
         timestamp: u64,
         start_time: u64,
         duration: u64,
+        refer: Option<bool>,
         #[serde(skip)]
         samples: Option<PcmBuf>,
     },
@@ -110,6 +112,7 @@ pub enum SessionEvent {
         completed: bool,
         interrupt_point: Option<String>,
         text: Option<String>,
+        refer: Option<bool>,
     },
     ///Inactivity timeout
     Inactivity {
@@ -164,6 +167,7 @@ pub enum SessionEvent {
         is_filler: Option<bool>,
         confidence: Option<f32>,
         task_id: Option<String>,
+        refer: Option<bool>,
     },
     AsrDelta {
         track_id: String,
@@ -175,6 +179,7 @@ pub enum SessionEvent {
         is_filler: Option<bool>,
         confidence: Option<f32>,
         task_id: Option<String>,
+        refer: Option<bool>,
     },
     Metrics {
         timestamp: u64,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -169,6 +169,7 @@ pub struct ReferOption {
     pub denoise: Option<bool>,
     pub timeout: Option<u32>,
     pub moh: Option<String>,
+    pub vad: Option<VADOption>,
     pub asr: Option<TranscriptionOption>,
     /// hangup after the call is ended
     pub auto_hangup: Option<bool>,

--- a/src/media/realtime_processor.rs
+++ b/src/media/realtime_processor.rs
@@ -190,6 +190,7 @@ async fn run_realtime_loop(
                                 start_time: v["audio_start_ms"].as_u64().unwrap_or_default(),
                                 is_filler: None,
                                 confidence: None,
+                                refer: None,
                             }).ok();
 
                             // Immediately signal interruption to stop current local playback
@@ -209,6 +210,7 @@ async fn run_realtime_loop(
                                     end_time: None,
                                     is_filler: None,
                                     confidence: None,
+                                    refer: None,
                                 }).ok();
                             }
                         }

--- a/src/media/vad/mod.rs
+++ b/src/media/vad/mod.rs
@@ -36,6 +36,8 @@ pub struct VADOption {
     pub endpoint: Option<String>,
     pub secret_key: Option<String>,
     pub secret_id: Option<String>,
+    #[serde(skip)]
+    pub refer: Option<bool>,
 }
 
 impl Default for VADOption {
@@ -52,6 +54,7 @@ impl Default for VADOption {
             endpoint: None,
             secret_key: None,
             secret_id: None,
+            refer: None,
         }
     }
 }
@@ -109,6 +112,7 @@ struct VadProcessorInner {
     triggered_event_sent: bool,
     current_speech_start: Option<u64>,
     temp_end: Option<u64>,
+    refer: Option<bool>,
 }
 pub struct VadProcessor {
     inner: VadProcessorInner,
@@ -174,6 +178,7 @@ impl VadProcessorInner {
                         start_time,
                         is_filler: None, // Will be enriched by MFCC or ASR
                         confidence: Some(1.0),
+                        refer: self.refer,
                     };
                     self.event_sender.send(event).ok();
                     self.triggered_event_sent = true;
@@ -211,6 +216,7 @@ impl VadProcessorInner {
                                 start_time,
                                 duration,
                                 samples: Some(samples_vec),
+                                refer: self.refer,
                             };
                             self.event_sender.send(event).ok();
                         }
@@ -233,6 +239,7 @@ impl VadProcessorInner {
                             start_time: temp_end,
                             duration: timeout_duration,
                             samples: None,
+                            refer: self.refer,
                         };
                         self.event_sender.send(event).ok();
                         self.temp_end = Some(timestamp);
@@ -278,6 +285,7 @@ impl VadProcessor {
         event_sender: EventSender,
         option: VADOption,
     ) -> Result<Self> {
+        let refer = option.refer;
         let inner = VadProcessorInner {
             vad: engine,
             event_sender,
@@ -287,6 +295,7 @@ impl VadProcessor {
             triggered: false,
             current_speech_start: None,
             temp_end: None,
+            refer,
         };
         Ok(Self { inner })
     }

--- a/src/playbook/handler/dtmf_collector_tests.rs
+++ b/src/playbook/handler/dtmf_collector_tests.rs
@@ -457,6 +457,7 @@ async fn test_collector_on_event_ignores_asr() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
 
     let commands = handler.on_event(&event).await?;

--- a/src/playbook/handler/tests.rs
+++ b/src/playbook/handler/tests.rs
@@ -145,6 +145,7 @@ async fn handler_applies_tool_instructions() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
 
     let commands = handler.on_event(&event).await?;
@@ -200,6 +201,7 @@ async fn handler_requeries_after_rag() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
 
     let commands = handler.on_event(&event).await?;
@@ -263,6 +265,7 @@ async fn test_full_dialogue_flow() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
     let commands = handler.on_event(&event).await?;
     // "Hello! How can I help you today?" -> split into two + EOS
@@ -284,6 +287,7 @@ async fn test_full_dialogue_flow() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
     let commands = handler.on_event(&event).await?;
     assert_eq!(commands.len(), 1);
@@ -310,6 +314,7 @@ async fn test_full_dialogue_flow() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
     let commands = handler.on_event(&event).await?;
     // Should have Tts with auto_hangup
@@ -358,6 +363,7 @@ async fn test_xml_tools_and_sentence_splitting() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
 
     let commands = handler.on_event(&event).await?;
@@ -440,6 +446,7 @@ async fn test_interruption_logic() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
     handler.on_event(&event).await?;
     assert!(handler.is_speaking);
@@ -458,6 +465,7 @@ async fn test_interruption_logic() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
     let commands = handler.on_event(&event).await?;
     assert_eq!(commands.len(), 1);
@@ -502,6 +510,7 @@ async fn test_rag_iteration_limit() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
 
     let commands = handler.on_event(&event).await?;
@@ -555,6 +564,7 @@ async fn test_follow_up_logic() -> Result<()> {
         start_time: 0,
         duration: 50,
         samples: None,
+        refer: None,
     };
     let commands = handler.on_event(&event).await?;
     assert!(commands.is_empty(), "Should not trigger if < timeout");
@@ -570,6 +580,7 @@ async fn test_follow_up_logic() -> Result<()> {
         start_time: 0,
         duration: 100,
         samples: None,
+        refer: None,
     };
     let commands = handler.on_event(&event).await?;
     assert_eq!(commands.len(), 1, "Should trigger follow-up 1");
@@ -601,6 +612,7 @@ async fn test_follow_up_logic() -> Result<()> {
         start_time: 0,
         duration: 100,
         samples: None,
+        refer: None,
     };
     let commands = handler.on_event(&event).await?;
     assert_eq!(commands.len(), 1, "Should trigger follow-up 2");
@@ -627,6 +639,7 @@ async fn test_follow_up_logic() -> Result<()> {
         start_time: 0,
         duration: 100,
         samples: None,
+        refer: None,
     };
     let commands = handler.on_event(&event).await?;
     assert_eq!(commands.len(), 1, "Should hangup after max count");
@@ -643,6 +656,7 @@ async fn test_follow_up_logic() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
 
     let _ = handler.on_event(&event).await?;
@@ -684,6 +698,7 @@ async fn test_interruption_protection_period() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
     handler.on_event(&event).await?;
     assert!(handler.is_speaking);
@@ -699,6 +714,7 @@ async fn test_interruption_protection_period() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
     let commands = handler.on_event(&event).await?;
     // Should be ignored due to protection period
@@ -739,6 +755,7 @@ async fn test_interruption_filler_word() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
     handler.on_event(&event).await?;
     assert!(handler.is_speaking);
@@ -757,6 +774,7 @@ async fn test_interruption_filler_word() -> Result<()> {
         is_filler: Some(true),
         confidence: None,
         task_id: None,
+        refer: None,
     };
     let commands = handler.on_event(&event).await?;
     // Should be ignored
@@ -774,6 +792,7 @@ async fn test_interruption_filler_word() -> Result<()> {
         is_filler: Some(false),
         confidence: None,
         task_id: None,
+        refer: None,
     };
     let commands = handler.on_event(&event).await?;
     // Should trigger interruption
@@ -808,6 +827,7 @@ async fn test_eou_early_response() -> Result<()> {
         completed: true,
         interrupt_point: None,
         text: Some("User's final utterance".to_string()),
+        refer: None,
     };
     let commands = handler.on_event(&event).await?;
     assert_eq!(commands.len(), 1);
@@ -897,6 +917,7 @@ async fn test_rolling_summary() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
 
     let commands = handler.on_event(&event).await?;

--- a/src/transcription/aliyun.rs
+++ b/src/transcription/aliyun.rs
@@ -297,6 +297,7 @@ impl AliyunAsrClient {
         let track_id_for_recv = ctx.track_id.clone();
         let track_id_for_send = ctx.track_id.clone();
         let aliyun_task_id_for_finish = aliyun_task_id.clone();
+        let refer = ctx.option.refer;
 
         let recv_loop = async move {
             let track_id = track_id_for_recv;
@@ -357,6 +358,7 @@ impl AliyunAsrClient {
                                         is_filler: None,
                                         confidence: None,
                                         task_id: None,
+                                        refer,
                                     }
                                 } else {
                                     SessionEvent::AsrDelta {
@@ -369,6 +371,7 @@ impl AliyunAsrClient {
                                         is_filler: None,
                                         confidence: None,
                                         task_id: None,
+                                        refer,
                                     }
                                 };
                                 event_sender.send(event).ok();

--- a/src/transcription/mod.rs
+++ b/src/transcription/mod.rs
@@ -80,6 +80,8 @@ pub struct TranscriptionOption {
     pub endpoint: Option<String>,
     pub extra: Option<HashMap<String, String>>,
     pub start_when_answer: Option<bool>,
+    #[serde(skip)]
+    pub refer: Option<bool>,
 }
 
 impl std::fmt::Display for TranscriptionType {

--- a/src/transcription/sensevoice.rs
+++ b/src/transcription/sensevoice.rs
@@ -96,6 +96,7 @@ impl SensevoiceAsrClientBuilder {
                 event_sender,
                 input_rate,
                 vad_option,
+                option.refer,
             ));
 
             let inner = SensevoiceAsrClientInner {
@@ -117,6 +118,7 @@ async fn process_stream(
     event_sender: EventSender,
     input_rate: u32,
     vad_option: VADOption,
+    refer: Option<bool>,
 ) {
     // Buffer for accumulating audio samples (target rate 16000)
     let mut buffer: Vec<i16> = Vec::with_capacity(16000 * 10);
@@ -250,6 +252,7 @@ async fn process_stream(
                             is_filler: None,
                             confidence: Some(1.0),
                             task_id: None,
+                            refer,
                         };
 
                         if let Err(e) = event_sender.send(event) {

--- a/src/transcription/tencent_cloud.rs
+++ b/src/transcription/tencent_cloud.rs
@@ -191,6 +191,7 @@ impl TencentCloudAsrClientBuilder {
                     audio_rx,
                     event_sender.clone(),
                     token,
+                    inner.option.refer,
                 )
                 .await
                 {
@@ -356,6 +357,7 @@ impl TencentCloudAsrClient {
         mut audio_rx: mpsc::UnboundedReceiver<Vec<u8>>,
         event_sender: EventSender,
         token: CancellationToken,
+        refer: Option<bool>,
     ) -> Result<()> {
         let (mut ws_sender, mut ws_receiver) = ws_stream.split();
         let begin_time = crate::media::get_timestamp();
@@ -394,6 +396,7 @@ impl TencentCloudAsrClient {
                                             is_filler: None,
                                             confidence: None,
                                             task_id: response.task_id.take(),
+                                            refer,
                                         }
                                     } else {
                                         SessionEvent::AsrDelta {
@@ -406,6 +409,7 @@ impl TencentCloudAsrClient {
                                             is_filler: None,
                                             confidence: None,
                                             task_id: response.task_id.take(),
+                                            refer,
                                         }
                                     };
                                     event_sender.send(event).ok()?;

--- a/tests/asr_pause_resume_test.rs
+++ b/tests/asr_pause_resume_test.rs
@@ -30,6 +30,7 @@ async fn test_refer_option_pause_parent_asr_field() {
         timeout: None,
         moh: None,
         asr: None,
+        vad: None,
         sip: None,
         call_id: None,
     };
@@ -43,6 +44,7 @@ async fn test_refer_option_pause_parent_asr_field() {
         timeout: None,
         moh: None,
         asr: None,
+        vad: None,
         sip: None,
         call_id: None,
     };
@@ -57,6 +59,7 @@ async fn test_refer_option_pause_parent_asr_field() {
         timeout: None,
         moh: None,
         asr: None,
+        vad: None,
         sip: None,
         call_id: None,
     };
@@ -133,6 +136,7 @@ async fn test_refer_option_serialization() -> Result<()> {
         timeout: None,
         moh: None,
         asr: None,
+        vad: None,
         sip: None,
         call_id: None,
     };

--- a/tests/autohangup_headers_test.rs
+++ b/tests/autohangup_headers_test.rs
@@ -109,6 +109,7 @@ async fn test_autohangup_headers_stored_in_extras() -> Result<()> {
         confidence: None,
         task_id: None,
         timestamp: 0,
+        refer: None,
     };
 
     let _ = handler.on_event(&event).await?;
@@ -201,6 +202,7 @@ async fn test_autohangup_without_sip_config() -> Result<()> {
         confidence: None,
         task_id: None,
         timestamp: 0,
+        refer: None,
     };
 
     let _ = handler.on_event(&event).await?;
@@ -304,6 +306,7 @@ async fn test_autohangup_headers_with_template_variables() -> Result<()> {
         confidence: None,
         task_id: None,
         timestamp: 0,
+        refer: None,
     };
 
     let _ = handler.on_event(&event).await?;

--- a/tests/call_tests.rs
+++ b/tests/call_tests.rs
@@ -68,6 +68,7 @@ impl MockAsrClientBuilder {
                             is_filler: None,
                             confidence: None,
                             task_id: None,
+                            refer: None,
                         };
                         let _ = event_sender.send(event);
                     }

--- a/tests/multi_scene_test.rs
+++ b/tests/multi_scene_test.rs
@@ -167,6 +167,7 @@ async fn test_scene_transition_logic() -> Result<()> {
         is_filler: Some(false),
         confidence: Some(1.0),
         task_id: None,
+        refer: None,
     };
 
     let commands = handler.on_event(&event).await?;

--- a/tests/playbook_runner_tests.rs
+++ b/tests/playbook_runner_tests.rs
@@ -153,6 +153,7 @@ async fn test_playbook_run_flow() -> Result<()> {
         is_filler: None,
         confidence: None,
         task_id: None,
+        refer: None,
     };
 
     // Send event


### PR DESCRIPTION
Adds a `refer: Option<bool>` field to session events so consumers can distinguish whether an ASR or VAD event originated from a referred (transferred) call leg.

### Changes

New `refer` field on session events** (`src/event.rs`)
- Added to `AsrFinal`, `AsrDelta`, `Silence`, and `EouDetected` variants

**ASR backends** — each now receives and forwards the `refer` flag:
- `aliyun.rs` — passed from `TranscriptionOption.refer` into emitted events
- `tencent_cloud.rs` — threaded through the WebSocket receive loop
- `sensevoice.rs` — passed into `process_stream`

**VAD** (`src/media/vad/mod.rs`)
- Added `refer: Option<bool>` to `VADOption` (`#[serde(skip)]`) and `VadProcessorInner`
- All VAD-emitted events (`AsrFinal`, `Silence`) now carry the flag

**`TranscriptionOption`** (`src/transcription/mod.rs`)
- Added `refer: Option<bool>` with `#[serde(skip)]` — internal-only, not exposed via API

**`ReferOption`** (`src/lib.rs`)
- Added `vad: Option<VADOption>` so callers can configure VAD for referred legs

**`active_call.rs`**
- When starting a referred call, both `asr` and `vad` options have `refer = Some(true)` injected
- `Silence` events from input-timeout also carry `is_refer` from call state

**Tests** — updated all struct literals to include `refer: None