### PR TITLE
fix: ensure 603 Decline is transmitted before task cancellation

### DIFF
--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -963,7 +963,13 @@ impl ActiveCall {
                     ?code,
                     "rejecting call"
                 );
-                self.invitation.hangup(id, code, reason).await
+                let result = self.invitation.hangup(id, code, reason).await;
+                // Yield so the tokio scheduler can run the dialog.handle task and
+                // flush the queued 603 Decline UDP packet before the token cancel
+                // drops that future.
+                tokio::task::yield_now().await;
+                self.cancel_token.cancel();
+                result
             }
             None => {
                 let ready = self.call_state.write().await.ready_to_answer.take();
@@ -976,6 +982,7 @@ impl ActiveCall {
                     );
                     let dialog_id = dialog.id();
                     dialog.reject(code, reason).ok();
+                    tokio::task::yield_now().await;
                     self.invitation.dialog_layer.remove_dialog(&dialog_id);
                     self.cancel_token.cancel();
                 }

--- a/src/call/sip.rs
+++ b/src/call/sip.rs
@@ -533,7 +533,9 @@ impl Invitation {
     ) -> Result<()> {
         if let Some(call) = self.get_pending_call(&dialog_id) {
             call.dialog.reject(code, reason).ok();
-            call.token.cancel();
+            // Don't cancel the token here; the caller (do_reject) yields first so the
+            // app.rs join!(dialog.handle, invite_loop) task gets to run and actually
+            // transmit the queued 603 response before the token cancellation drops it.
         }
         match self.dialog_layer.get_dialog(&dialog_id) {
             Some(dialog) => {


### PR DESCRIPTION
https://github.com/miuda-ai/active-call/issues/88


When rejecting a pre-answer SIP call, `ServerInviteDialog::reject()` queues a `TransactionEvent::Respond(603)` onto a channel for the transaction loop to process. The transaction loop runs inside a `tokio::join!` in a separate task (`app.rs`). Previously, `cancel_token.cancel()` was called immediately after `reject()`, which caused the outer `tokio::select!` in `app.rs` to drop that join — cancelling the transaction loop before it could dequeue and transmit the 603 UDP packet.

**Fix:**
- Remove the early `call.token.cancel()` from `Invitation::hangup()` — this was the token that killed the `join!` task prematurely.
- Add `yield_now().await` before `cancel_token.cancel()` in both `do_reject` branches. This yields the `call_handler_core` task, allowing the `app.rs` task to run and flush the queued 603 over UDP before the cancellation drops it.