### PR TITLE
feat: detach mode — keep WebSocket session alive after call hangup

### DIFF
--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -213,6 +213,139 @@ mod tests {
 
         Ok(())
     }
+
+    async fn make_active_call(detach: bool) -> Arc<ActiveCall> {
+        let mut config = Config::default();
+        config.udp_port = 0;
+        config.media_cache_path = "/tmp/mediacache".to_string();
+        let app_state = AppStateBuilder::new()
+            .with_config(config)
+            .with_stream_engine(Arc::new(StreamEngine::default()))
+            .build()
+            .await
+            .unwrap();
+
+        let cancel_token = CancellationToken::new();
+        Arc::new(
+            ActiveCall::new(
+                ActiveCallType::Sip,
+                cancel_token,
+                "test-session".to_string(),
+                app_state.invitation.clone(),
+                app_state.clone(),
+                TrackConfig::default(),
+                None,
+                false,
+                None,
+                None,
+                None,
+            )
+            .with_detach(detach),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_detach_hangup_keeps_session_alive() -> Result<()> {
+        let active_call = make_active_call(true).await;
+
+        // Simulate the token that would be created when a SIP dialog is set up
+        let main_token = active_call.cancel_token.child_token();
+        active_call.call_state.write().await.main_call_token = Some(main_token.clone());
+
+        active_call.do_hangup(None, None, None).await?;
+
+        // Session token must still be alive
+        assert!(
+            !active_call.cancel_token.is_cancelled(),
+            "session cancel_token should NOT be cancelled in detach mode"
+        );
+        // Main-call token must be cancelled
+        assert!(
+            main_token.is_cancelled(),
+            "main_call_token should be cancelled by do_hangup"
+        );
+        // Token should be taken out of state
+        assert!(
+            active_call
+                .call_state
+                .read()
+                .await
+                .main_call_token
+                .is_none(),
+            "main_call_token should be cleared from state after hangup"
+        );
+        // Hangup reason must be set before the token was cancelled (race-free ordering)
+        assert!(
+            active_call
+                .call_state
+                .read()
+                .await
+                .hangup_reason
+                .is_some(),
+            "hangup_reason should be set"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_no_detach_hangup_stops_media_stream() -> Result<()> {
+        let active_call = make_active_call(false).await;
+
+        active_call.do_hangup(None, None, None).await?;
+
+        assert!(
+            active_call.media_stream.cancel_token.is_cancelled(),
+            "media_stream cancel_token should be cancelled in non-detach mode"
+        );
+        assert!(
+            !active_call.cancel_token.is_cancelled(),
+            "session cancel_token should not be directly cancelled by do_hangup"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_detach_make_main_call_token_is_child() -> Result<()> {
+        let active_call = make_active_call(true).await;
+
+        let child_token = active_call.make_main_call_token().await;
+
+        assert!(
+            !child_token.is_cancelled(),
+            "child token should not be cancelled initially"
+        );
+
+        // Cancelling the session token must cascade to the child
+        active_call.cancel_token.cancel();
+
+        assert!(
+            child_token.is_cancelled(),
+            "child token should be cancelled when session token is cancelled"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_no_detach_make_main_call_token_is_session_token() -> Result<()> {
+        let active_call = make_active_call(false).await;
+
+        let token = active_call.make_main_call_token().await;
+
+        // In non-detach mode, the returned token IS the session token
+        assert_eq!(
+            token.is_cancelled(),
+            active_call.cancel_token.is_cancelled(),
+            "non-detach token should mirror the session token state"
+        );
+
+        active_call.cancel_token.cancel();
+
+        assert!(
+            token.is_cancelled(),
+            "token should be cancelled when session token is cancelled"
+        );
+        Ok(())
+    }
 }
 
 #[derive(Deserialize)]
@@ -1784,8 +1917,26 @@ impl ActiveCall {
                     }
                 }
 
+                // Reset per-call state so a re-invite in detach mode starts clean.
+                // answer must be None or create_outgoing_sip_track will skip storing the new SDP.
+                // ssrc must be fresh so auto_hangup triggers don't fire for the wrong call.
+                {
+                    let mut cs = self.call_state.write().await;
+                    cs.answer = None;
+                    cs.ring_time = None;
+                    cs.answer_time = None;
+                    cs.hangup_reason = None;
+                    cs.ssrc = rand::random::<u32>();
+                    cs.auto_hangup = None;
+                }
+
                 let mut invite_option = option.build_invite_option()?;
-                invite_option.call_id = Some(self.session_id.clone());
+                // Call-ID must be unique per dialog; reusing session_id breaks re-invites.
+                invite_option.call_id = Some(format!(
+                    "{}.{}",
+                    self.session_id,
+                    rand::random::<u32>()
+                ));
 
                 let dialog_token = self.make_main_call_token().await;
                 match self

--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -252,7 +252,7 @@ mod tests {
         let main_token = active_call.cancel_token.child_token();
         active_call.call_state.write().await.main_call_token = Some(main_token.clone());
 
-        active_call.do_hangup(None, None, None).await?;
+        active_call.do_hangup(None, None, None, None).await?;
 
         // Session token must still be alive
         assert!(
@@ -291,7 +291,7 @@ mod tests {
     async fn test_no_detach_hangup_stops_media_stream() -> Result<()> {
         let active_call = make_active_call(false).await;
 
-        active_call.do_hangup(None, None, None).await?;
+        active_call.do_hangup(None, None, None, None).await?;
 
         assert!(
             active_call.media_stream.cancel_token.is_cancelled(),
@@ -346,6 +346,99 @@ mod tests {
         );
         Ok(())
     }
+
+    async fn setup_refer_token(active_call: &Arc<ActiveCall>) -> CancellationToken {
+        let refer_token = active_call.cancel_token.child_token();
+        active_call.call_state.write().await.refer_call_token = Some(refer_token.clone());
+        refer_token
+    }
+
+    // refer: None — detach mode: main call and refer call both cancelled, session stays alive.
+    #[tokio::test]
+    async fn test_hangup_none_detach_cancels_both() -> Result<()> {
+        let active_call = make_active_call(true).await;
+        let main_token = active_call.cancel_token.child_token();
+        active_call.call_state.write().await.main_call_token = Some(main_token.clone());
+        let refer_token = setup_refer_token(&active_call).await;
+
+        active_call.do_hangup(None, None, None, None).await?;
+
+        assert!(!active_call.cancel_token.is_cancelled(), "session should stay alive");
+        assert!(main_token.is_cancelled(), "main call should be cancelled");
+        assert!(refer_token.is_cancelled(), "refer call should be cancelled");
+        Ok(())
+    }
+
+    // refer: None — non-detach mode: media stream stopped and refer call cancelled.
+    #[tokio::test]
+    async fn test_hangup_none_no_detach_cancels_refer() -> Result<()> {
+        let active_call = make_active_call(false).await;
+        let refer_token = setup_refer_token(&active_call).await;
+
+        active_call.do_hangup(None, None, None, None).await?;
+
+        assert!(active_call.media_stream.cancel_token.is_cancelled(), "media stream should stop");
+        assert!(refer_token.is_cancelled(), "refer call should be cancelled");
+        Ok(())
+    }
+
+    // refer: Some(true) — detach mode: only refer call cancelled, main call untouched.
+    #[tokio::test]
+    async fn test_hangup_refer_true_detach_cancels_refer_only() -> Result<()> {
+        let active_call = make_active_call(true).await;
+        let main_token = active_call.cancel_token.child_token();
+        active_call.call_state.write().await.main_call_token = Some(main_token.clone());
+        let refer_token = setup_refer_token(&active_call).await;
+
+        active_call.do_hangup(None, None, None, Some(true)).await?;
+
+        assert!(!active_call.cancel_token.is_cancelled(), "session should stay alive");
+        assert!(!main_token.is_cancelled(), "main call should NOT be cancelled");
+        assert!(refer_token.is_cancelled(), "refer call should be cancelled");
+        Ok(())
+    }
+
+    // refer: Some(true) — non-detach mode: only refer call cancelled, media stream untouched.
+    #[tokio::test]
+    async fn test_hangup_refer_true_no_detach_cancels_refer_only() -> Result<()> {
+        let active_call = make_active_call(false).await;
+        let refer_token = setup_refer_token(&active_call).await;
+
+        active_call.do_hangup(None, None, None, Some(true)).await?;
+
+        assert!(!active_call.media_stream.cancel_token.is_cancelled(), "media stream should NOT stop");
+        assert!(refer_token.is_cancelled(), "refer call should be cancelled");
+        Ok(())
+    }
+
+    // refer: Some(false) — detach mode: only main call cancelled, refer call stays alive.
+    #[tokio::test]
+    async fn test_hangup_refer_false_detach_cancels_main_only() -> Result<()> {
+        let active_call = make_active_call(true).await;
+        let main_token = active_call.cancel_token.child_token();
+        active_call.call_state.write().await.main_call_token = Some(main_token.clone());
+        let refer_token = setup_refer_token(&active_call).await;
+
+        active_call.do_hangup(None, None, None, Some(false)).await?;
+
+        assert!(!active_call.cancel_token.is_cancelled(), "session should stay alive");
+        assert!(main_token.is_cancelled(), "main call should be cancelled");
+        assert!(!refer_token.is_cancelled(), "refer call should NOT be cancelled");
+        Ok(())
+    }
+
+    // refer: Some(false) — non-detach mode: main_call_token is None, so nothing is cancelled.
+    #[tokio::test]
+    async fn test_hangup_refer_false_no_detach_is_noop() -> Result<()> {
+        let active_call = make_active_call(false).await;
+        let refer_token = setup_refer_token(&active_call).await;
+
+        active_call.do_hangup(None, None, None, Some(false)).await?;
+
+        assert!(!active_call.media_stream.cancel_token.is_cancelled(), "media stream should NOT stop");
+        assert!(!refer_token.is_cancelled(), "refer call should NOT be cancelled");
+        Ok(())
+    }
 }
 
 #[derive(Deserialize)]
@@ -397,6 +490,8 @@ pub struct ActiveCallState {
     pub pending_asr_resume: Option<(u32, TranscriptionOption)>,
     // In detach mode, cancel only this token to hang up the main call without closing the session
     pub main_call_token: Option<CancellationToken>,
+    // Cancel this token to hang up only the refer call, leaving the main call alive
+    pub refer_call_token: Option<CancellationToken>,
 }
 
 pub type ActiveCallRef = Arc<ActiveCall>;
@@ -675,7 +770,7 @@ impl ActiveCall {
                                     session_id = self.session_id,
                                     ssrc, "auto hangup when track end track_id:{}", track_id
                                 );
-                                self.do_hangup(Some(hangup_reason), None, None).await.ok();
+                                self.do_hangup(Some(hangup_reason), None, None, None).await.ok();
                             }
                         }
 
@@ -704,7 +799,7 @@ impl ActiveCall {
                             session_id = self.session_id,
                             track_id, "inactivity timeout reached, hanging up"
                         );
-                        self.do_hangup(Some(CallRecordHangupReason::InactivityTimeout), None, None)
+                        self.do_hangup(Some(CallRecordHangupReason::InactivityTimeout), None, None, None)
                             .await
                             .ok();
                     }
@@ -884,12 +979,13 @@ impl ActiveCall {
                 reason,
                 initiator,
                 headers,
+                refer,
             } => {
                 let reason = reason.map(|r| {
                     r.parse::<CallRecordHangupReason>()
                         .unwrap_or(CallRecordHangupReason::BySystem)
                 });
-                self.do_hangup(reason, initiator, headers).await
+                self.do_hangup(reason, initiator, headers, refer).await
             }
             Command::Refer {
                 caller,
@@ -1013,7 +1109,7 @@ impl ActiveCall {
                     code: None,
                 };
                 self.event_sender.send(error_event).ok();
-                self.do_hangup(Some(CallRecordHangupReason::BySystem), None, None)
+                self.do_hangup(Some(CallRecordHangupReason::BySystem), None, None, None)
                     .await
                     .ok();
                 return Err(e);
@@ -1049,7 +1145,7 @@ impl ActiveCall {
                     code: Some(486),
                 };
                 self.event_sender.send(rejet_event).ok();
-                self.do_hangup(Some(CallRecordHangupReason::BySystem), None, None)
+                self.do_hangup(Some(CallRecordHangupReason::BySystem), None, None, None)
                     .await
                     .ok();
                 return Err(anyhow::anyhow!("no pending call to accept"));
@@ -1385,26 +1481,42 @@ impl ActiveCall {
         reason: Option<CallRecordHangupReason>,
         initiator: Option<String>,
         headers: Option<HashMap<String, String>>,
+        refer: Option<bool>,
     ) -> Result<()> {
         info!(
             session_id = self.session_id,
             ?reason,
             ?initiator,
             ?headers,
+            ?refer,
             "do_hangup"
         );
+
+        // Hang up only the refer call, leaving the main call alive.
+        if refer == Some(true) {
+            if let Some(headers) = headers {
+                if let Some(refer_state) = self.call_state.read().await.refer_callstate.clone() {
+                    let h_val = serde_json::to_value(&headers).unwrap_or_default();
+                    let mut rs = refer_state.write().await;
+                    let mut extras = rs.extras.take().unwrap_or_default();
+                    extras.insert("_hangup_headers".to_string(), h_val);
+                    rs.extras = Some(extras);
+                }
+            }
+            let token = self.call_state.write().await.refer_call_token.take();
+            if let Some(token) = token {
+                token.cancel();
+            }
+            return Ok(());
+        }
 
         // Store headers in extras if provided
         if let Some(headers) = headers {
             let h_val = serde_json::to_value(&headers).unwrap_or_default();
-
-            {
-                let mut state = self.call_state.write().await;
-                let mut extras = state.extras.take().unwrap_or_default();
-                extras.insert("_hangup_headers".to_string(), h_val.clone());
-                state.extras = Some(extras);
-            }
-        } else {
+            let mut state = self.call_state.write().await;
+            let mut extras = state.extras.take().unwrap_or_default();
+            extras.insert("_hangup_headers".to_string(), h_val);
+            state.extras = Some(extras);
         }
 
         let hangup_reason = match initiator.as_deref() {
@@ -1414,7 +1526,8 @@ impl ActiveCall {
             _ => reason.unwrap_or(CallRecordHangupReason::BySystem),
         };
 
-        if self.detach {
+        // refer: Some(false) — hang up main call, keep refer call alive (always use detach logic).
+        if self.detach || refer == Some(false) {
             // Set reason before cancelling so on_terminated() sees it and uses it in the event.
             self.call_state
                 .write()
@@ -1434,6 +1547,14 @@ impl ActiveCall {
                 .write()
                 .await
                 .set_hangup_reason(hangup_reason);
+        }
+
+        // refer: None — plain hangup means kill everything, including any active refer call.
+        if refer.is_none() {
+            let refer_token = self.call_state.write().await.refer_call_token.take();
+            if let Some(token) = refer_token {
+                token.cancel();
+            }
         }
         Ok(())
     }
@@ -1590,10 +1711,13 @@ impl ActiveCall {
             "do_refer"
         );
 
+        let refer_cancel_token = self.cancel_token.child_token();
+        self.call_state.write().await.refer_call_token = Some(refer_cancel_token.clone());
+
         let r = tokio::time::timeout(
             Duration::from_secs(timeout_secs as u64),
             self.create_outgoing_sip_track(
-                self.cancel_token.child_token(),
+                refer_cancel_token,
                 refer_call_state.clone(),
                 &track_id,
                 invite_option,
@@ -1605,7 +1729,9 @@ impl ActiveCall {
         .await;
 
         {
-            self.call_state.write().await.moh = None;
+            let mut cs = self.call_state.write().await;
+            cs.moh = None;
+            cs.refer_call_token = None;
         }
 
         let result = match r {

--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -1721,9 +1721,7 @@ impl ActiveCall {
         .await;
 
         {
-            let mut cs = self.call_state.write().await;
-            cs.moh = None;
-            cs.refer_call_token = None;
+            self.call_state.write().await.moh = None;
         }
 
         let result = match r {

--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -224,6 +224,7 @@ pub struct CallParams {
     #[serde(rename = "ping")]
     pub ping_interval: Option<u32>,
     pub server_side_track: Option<String>,
+    pub detach: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, Eq)]
@@ -261,6 +262,8 @@ pub struct ActiveCallState {
     pub audio_receiver: Option<WebsocketBytesReceiver>,
     pub ready_to_answer: Option<(String, Option<Box<dyn Track>>, ServerInviteDialog)>,
     pub pending_asr_resume: Option<(u32, TranscriptionOption)>,
+    // In detach mode, cancel only this token to hang up the main call without closing the session
+    pub main_call_token: Option<CancellationToken>,
 }
 
 pub type ActiveCallRef = Arc<ActiveCall>;
@@ -279,6 +282,7 @@ pub struct ActiveCall {
     pub cmd_sender: CommandSender,
     pub dump_events: bool,
     pub server_side_track_id: TrackId,
+    pub detach: bool,
 }
 
 pub struct ActiveCallGuard {
@@ -377,7 +381,13 @@ impl ActiveCall {
             cmd_sender,
             dump_events,
             server_side_track_id: server_side_track_id.unwrap_or("server-side-track".to_string()),
+            detach: false,
         }
+    }
+
+    pub fn with_detach(mut self, detach: bool) -> Self {
+        self.detach = detach;
+        self
     }
 
     pub async fn enqueue_command(&self, command: Command) -> Result<()> {
@@ -1271,13 +1281,27 @@ impl ActiveCall {
             _ => reason.unwrap_or(CallRecordHangupReason::BySystem),
         };
 
-        self.media_stream
-            .stop(Some(hangup_reason.to_string()), initiator);
+        if self.detach {
+            // Set reason before cancelling so on_terminated() sees it and uses it in the event.
+            self.call_state
+                .write()
+                .await
+                .set_hangup_reason(hangup_reason);
+            // Cancel only the main call's SIP dialog token, keeping the session and referred
+            // call alive. The dialog's Drop handler sends BYE and the hangup event.
+            let main_token = self.call_state.write().await.main_call_token.take();
+            if let Some(token) = main_token {
+                token.cancel();
+            }
+        } else {
+            self.media_stream
+                .stop(Some(hangup_reason.to_string()), initiator);
 
-        self.call_state
-            .write()
-            .await
-            .set_hangup_reason(hangup_reason);
+            self.call_state
+                .write()
+                .await
+                .set_hangup_reason(hangup_reason);
+        }
         Ok(())
     }
 
@@ -1680,6 +1704,16 @@ impl ActiveCall {
         Ok(track)
     }
 
+    async fn make_main_call_token(&self) -> CancellationToken {
+        if self.detach {
+            let token = self.cancel_token.child_token();
+            self.call_state.write().await.main_call_token = Some(token.clone());
+            token
+        } else {
+            self.cancel_token.clone()
+        }
+    }
+
     async fn setup_caller_track(&self, option: &CallOption) -> Result<()> {
         let hangup_headers = option
             .sip
@@ -1714,9 +1748,10 @@ impl ActiveCall {
                     .find_dialog_id_by_session_id(&self.session_id)
                 {
                     if let Some(pending_dialog) = self.invitation.get_pending_call(&dialog_id) {
+                        let dialog_token = self.make_main_call_token().await;
                         return self
                             .prepare_incoming_sip_track(
-                                self.cancel_token.clone(),
+                                dialog_token,
                                 self.call_state.clone(),
                                 &self.session_id,
                                 pending_dialog,
@@ -1752,9 +1787,10 @@ impl ActiveCall {
                 let mut invite_option = option.build_invite_option()?;
                 invite_option.call_id = Some(self.session_id.clone());
 
+                let dialog_token = self.make_main_call_token().await;
                 match self
                     .create_outgoing_sip_track(
-                        self.cancel_token.clone(),
+                        dialog_token,
                         self.call_state.clone(),
                         &self.session_id,
                         invite_option,
@@ -1804,9 +1840,10 @@ impl ActiveCall {
                     .find_dialog_id_by_session_id(&self.session_id)
                 {
                     if let Some(pending_dialog) = self.invitation.get_pending_call(&dialog_id) {
+                        let dialog_token = self.make_main_call_token().await;
                         return self
                             .prepare_incoming_sip_track(
-                                self.cancel_token.clone(),
+                                dialog_token,
                                 self.call_state.clone(),
                                 &self.session_id,
                                 pending_dialog,

--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -1492,33 +1492,6 @@ impl ActiveCall {
             "do_hangup"
         );
 
-        // Hang up only the refer call, leaving the main call alive.
-        if refer == Some(true) {
-            if let Some(headers) = headers {
-                if let Some(refer_state) = self.call_state.read().await.refer_callstate.clone() {
-                    let h_val = serde_json::to_value(&headers).unwrap_or_default();
-                    let mut rs = refer_state.write().await;
-                    let mut extras = rs.extras.take().unwrap_or_default();
-                    extras.insert("_hangup_headers".to_string(), h_val);
-                    rs.extras = Some(extras);
-                }
-            }
-            let token = self.call_state.write().await.refer_call_token.take();
-            if let Some(token) = token {
-                token.cancel();
-            }
-            return Ok(());
-        }
-
-        // Store headers in extras if provided
-        if let Some(headers) = headers {
-            let h_val = serde_json::to_value(&headers).unwrap_or_default();
-            let mut state = self.call_state.write().await;
-            let mut extras = state.extras.take().unwrap_or_default();
-            extras.insert("_hangup_headers".to_string(), h_val);
-            state.extras = Some(extras);
-        }
-
         let hangup_reason = match initiator.as_deref() {
             Some("caller") => CallRecordHangupReason::ByCaller,
             Some("callee") => CallRecordHangupReason::ByCallee,
@@ -1526,34 +1499,53 @@ impl ActiveCall {
             _ => reason.unwrap_or(CallRecordHangupReason::BySystem),
         };
 
-        // refer: Some(false) — hang up main call, keep refer call alive (always use detach logic).
-        if self.detach || refer == Some(false) {
-            // Set reason before cancelling so on_terminated() sees it and uses it in the event.
-            self.call_state
-                .write()
-                .await
-                .set_hangup_reason(hangup_reason);
-            // Cancel only the main call's SIP dialog token, keeping the session and referred
-            // call alive. The dialog's Drop handler sends BYE and the hangup event.
-            let main_token = self.call_state.write().await.main_call_token.take();
-            if let Some(token) = main_token {
-                token.cancel();
+        match refer {
+            Some(true) => {
+                // Hang up only the refer call, leaving the main call alive.
+                if let Some(refer_state) = self.call_state.read().await.refer_callstate.clone() {
+                    if let Some(headers) = headers {
+                        let h_val = serde_json::to_value(&headers).unwrap_or_default();
+                        let mut rs = refer_state.write().await;
+                        let mut extras = rs.extras.take().unwrap_or_default();
+                        extras.insert("_hangup_headers".to_string(), h_val);
+                        rs.extras = Some(extras);
+                    }
+                    // Set reason before cancelling so on_terminated() sees it and uses it in the event.
+                    refer_state.write().await.set_hangup_reason(hangup_reason);
+                }
+                if let Some(token) = self.call_state.write().await.refer_call_token.take() {
+                    token.cancel();
+                }
             }
-        } else {
-            self.media_stream
-                .stop(Some(hangup_reason.to_string()), initiator);
+            _ => {
+                // Store headers in main call state.
+                if let Some(headers) = headers {
+                    let h_val = serde_json::to_value(&headers).unwrap_or_default();
+                    let mut state = self.call_state.write().await;
+                    let mut extras = state.extras.take().unwrap_or_default();
+                    extras.insert("_hangup_headers".to_string(), h_val);
+                    state.extras = Some(extras);
+                }
 
-            self.call_state
-                .write()
-                .await
-                .set_hangup_reason(hangup_reason);
-        }
+                if self.detach || refer == Some(false) {
+                    // Hang up main call only; keep session (and refer call for Some(false)) alive.
+                    // Set reason before cancelling so on_terminated() sees it and uses it in the event.
+                    self.call_state.write().await.set_hangup_reason(hangup_reason);
+                    if let Some(token) = self.call_state.write().await.main_call_token.take() {
+                        token.cancel();
+                    }
+                } else {
+                    self.media_stream
+                        .stop(Some(hangup_reason.to_string()), initiator);
+                    self.call_state.write().await.set_hangup_reason(hangup_reason);
+                }
 
-        // refer: None — plain hangup means kill everything, including any active refer call.
-        if refer.is_none() {
-            let refer_token = self.call_state.write().await.refer_call_token.take();
-            if let Some(token) = refer_token {
-                token.cancel();
+                // refer: None — plain hangup kills everything, including any active refer call.
+                if refer.is_none() {
+                    if let Some(token) = self.call_state.write().await.refer_call_token.take() {
+                        token.cancel();
+                    }
+                }
             }
         }
         Ok(())

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -76,6 +76,7 @@ pub enum Command {
         reason: Option<String>,
         initiator: Option<String>,
         headers: Option<HashMap<String, String>>,
+        refer: Option<bool>,
     },
     Refer {
         caller: String,

--- a/src/handler/handler.rs
+++ b/src/handler/handler.rs
@@ -108,23 +108,27 @@ pub async fn call_handler_core(
     event_sender_to_client: tokio::sync::mpsc::UnboundedSender<crate::event::SessionEvent>,
     extras: Option<HashMap<String, serde_json::Value>>,
     playbook_name: Option<String>,
+    detach: bool,
 ) -> Option<HashMap<String, serde_json::Value>> {
     let _cancel_guard = cancel_token.clone().drop_guard();
     let track_config = TrackConfig::default();
 
-    let active_call = Arc::new(ActiveCall::new(
-        call_type.clone(),
-        cancel_token.clone(),
-        session_id.clone(),
-        app_state.invitation.clone(),
-        app_state.clone(),
-        track_config,
-        Some(audio_receiver),
-        dump_events,
-        server_side_track,
-        extras,
-        None,
-    ));
+    let active_call = Arc::new(
+        ActiveCall::new(
+            call_type.clone(),
+            cancel_token.clone(),
+            session_id.clone(),
+            app_state.invitation.clone(),
+            app_state.clone(),
+            track_config,
+            Some(audio_receiver),
+            dump_events,
+            server_side_track,
+            extras,
+            None,
+        )
+        .with_detach(detach),
+    );
 
     // Load playbook: prefer direct parameter, fall back to pending_playbooks
     // (pending_playbooks is used by the run_playbook HTTP endpoint)
@@ -322,6 +326,7 @@ pub async fn call_handler(
     let server_side_track = params.server_side_track.clone();
     let dump_events = params.dump_events.unwrap_or(true);
     let ping_interval = params.ping_interval.unwrap_or(20);
+    let detach = params.detach.unwrap_or(false);
 
     let resp = ws.on_upgrade(move |socket| async move {
         let (mut ws_sender, mut ws_receiver) = socket.split();
@@ -349,6 +354,7 @@ pub async fn call_handler(
                 event_sender_to_client,
                 None, // extras — not used for WebSocket calls
                 None, // playbook_name — falls back to pending_playbooks
+                detach,
             )
             .await;
         });
@@ -365,7 +371,7 @@ pub async fn call_handler(
                                 continue;
                             }
                         };
-                        if let Err(_) = command_sender.send(command) {
+                        if command_sender.send(command).is_err() && !detach {
                             break;
                         }
                     }
@@ -398,13 +404,18 @@ pub async fn call_handler(
             }
         };
 
-        select! {
-            _ = recv_from_ws_loop => {
-                info!(session_id, "WebSocket receive loop ended");
-            },
-            _ = send_to_ws_loop => {
-                info!(session_id, "WebSocket send loop ended");
-            },
+        if detach {
+            join!(recv_from_ws_loop, send_to_ws_loop);
+            info!(session_id, "WebSocket detached session closed");
+        } else {
+            select! {
+                _ = recv_from_ws_loop => {
+                    info!(session_id, "WebSocket receive loop ended");
+                },
+                _ = send_to_ws_loop => {
+                    info!(session_id, "WebSocket send loop ended");
+                },
+            }
         }
 
         cancel_token.cancel();
@@ -626,6 +637,7 @@ mod tests {
             event_sender,
             Some(extras), // extras passed directly
             None,         // no playbook
+            false,        // detach
         )
         .await;
 

--- a/src/handler/handler.rs
+++ b/src/handler/handler.rs
@@ -650,4 +650,73 @@ mod tests {
             "session-scoped extras should be preserved"
         );
     }
+
+    #[tokio::test]
+    async fn test_call_handler_core_detach_survives_hangup() {
+        use crate::app::AppStateBuilder;
+        use crate::call::{ActiveCallType, Command};
+        use crate::config::Config;
+
+        let mut config = Config::default();
+        config.udp_port = 0;
+        let app_state = AppStateBuilder::new()
+            .with_config(config)
+            .build()
+            .await
+            .expect("Failed to build app state");
+
+        let cancel_token = CancellationToken::new();
+        let (_audio_sender, audio_receiver) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
+        let (command_sender, command_receiver) = tokio::sync::mpsc::unbounded_channel::<Command>();
+        let (event_sender, _event_receiver) =
+            tokio::sync::mpsc::unbounded_channel::<crate::event::SessionEvent>();
+
+        // Spawn call_handler_core with detach=true
+        let handle = tokio::spawn(call_handler_core(
+            ActiveCallType::Sip,
+            "test-detach-survives".to_string(),
+            app_state,
+            cancel_token,
+            audio_receiver,
+            None,
+            false,
+            0,
+            command_receiver,
+            event_sender,
+            None,
+            None,
+            true, // detach
+        ));
+
+        // Give the handler a moment to start
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        // Send Hangup and wait briefly — in detach mode the handler should NOT exit
+        command_sender
+            .send(Command::Hangup {
+                reason: None,
+                initiator: None,
+                headers: None,
+            })
+            .ok();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        assert!(
+            !handle.is_finished(),
+            "call_handler_core should remain alive after Hangup in detach mode"
+        );
+
+        // Dropping the command sender (simulating WS disconnect) should end the session
+        drop(command_sender);
+        let result = tokio::time::timeout(
+            tokio::time::Duration::from_secs(2),
+            handle,
+        )
+        .await;
+        assert!(
+            result.is_ok(),
+            "call_handler_core should terminate after command sender is dropped"
+        );
+    }
 }

--- a/src/handler/handler.rs
+++ b/src/handler/handler.rs
@@ -619,6 +619,7 @@ mod tests {
                 reason: None,
                 initiator: None,
                 headers: None,
+                refer: None,
             })
             .ok();
         drop(command_sender);
@@ -697,6 +698,7 @@ mod tests {
                 reason: None,
                 initiator: None,
                 headers: None,
+                refer: None,
             })
             .ok();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -273,6 +273,7 @@ async fn main() -> Result<()> {
                 event_sender,
                 None,     // extras
                 playbook, // playbook_name — passed directly
+                false,    // detach
             )
             .await;
         });

--- a/src/playbook/dialogue.rs
+++ b/src/playbook/dialogue.rs
@@ -27,6 +27,7 @@ mod tests {
                 reason: Some("start".to_string()),
                 initiator: Some("tester".to_string()),
                 headers: None,
+                refer: None,
             }])
         }
 
@@ -36,6 +37,7 @@ mod tests {
                     reason: Some("event".to_string()),
                     initiator: Some("tester".to_string()),
                     headers: None,
+                    refer: None,
                 }])
             } else {
                 Ok(vec![])

--- a/src/playbook/handler/mod.rs
+++ b/src/playbook/handler/mod.rs
@@ -645,6 +645,7 @@ impl LlmHandler {
                     reason: Some("DTMF Hangup".to_string()),
                     initiator: Some("ai".to_string()),
                     headers,
+                    refer: None,
                 }])
             }
         }
@@ -1318,6 +1319,7 @@ impl LlmHandler {
                     reason: reason.clone(),
                     initiator: initiator.clone(),
                     headers,
+                    refer: None,
                 });
                 Ok(false)
             }
@@ -1728,6 +1730,7 @@ impl LlmHandler {
                 reason: Some("Max follow-up reached".to_string()),
                 initiator: Some("system".to_string()),
                 headers,
+                refer: None,
             }]);
         }
 
@@ -1756,6 +1759,7 @@ impl LlmHandler {
                     reason: args["reason"].as_str().map(|s| s.to_string()),
                     initiator: Some("ai".to_string()),
                     headers,
+                    refer: None,
                 }])
             }
             "transfer_call" | "refer_call" => {

--- a/src/useragent/playbook_handler.rs
+++ b/src/useragent/playbook_handler.rs
@@ -216,6 +216,7 @@ impl InvitationHandler for PlaybookInvitationHandler {
                                 event_sender,
                                 extras_for_call,
                                 Some(playbook_for_call),
+                                false, // detach
                             )
                             .await;
                             let _ = extras_tx.send(result);

--- a/tests/call_tests.rs
+++ b/tests/call_tests.rs
@@ -333,6 +333,7 @@ async fn test_webrtc_call_workflow() -> Result<()> {
         reason: None,
         initiator: None,
         headers: None,
+        refer: None,
     };
     ws_stream
         .send(Message::Text(serde_json::to_string(&hangup_cmd)?.into()))


### PR DESCRIPTION
Summary

Adds a `?detach=true` query parameter to the `/call/sip` (and `/call`) WebSocket endpoint. In detach mode the WebSocket session stays open after the main call hangs up, so any referred call keeps running and a new `Invite` command can be issued to start another outgoing SIP leg within the same session.

### Motivation

Without this, a `Hangup` on the main call tears down the entire session — including any active refer target and the WebSocket connection itself. The detach mode is designed for flows like:

```
Connect (detach=true) → Accept → Refer → Hangup (refer stays) → Invite → Hangup → Invite → …
```

### Changes

**`?detach=true` query parameter** (`CallParams`)
- Parsed from the WebSocket upgrade request and forwarded through `call_handler_core`.

**`ActiveCall::with_detach(bool)` builder method**
- Adds `detach: bool` to `ActiveCall` without touching the constructor signature used by existing callers.

**Child token per SIP dialog** (`make_main_call_token`)
- In detach mode, each SIP dialog gets a `child_token()` instead of the session `cancel_token`. Dialog teardown cancels only the child — the session and media stream remain alive.
- A reference to the child token (`main_call_token`) is stored in `ActiveCallState` so `do_hangup` can cancel it explicitly.

**`do_hangup` in detach mode**
- Cancels `main_call_token` (child) instead of stopping the media stream.
- Hangup reason is written to state *before* the token is cancelled to avoid a race with `on_terminated()`.

**Re-invite state reset** (fix: multiple invites in single session)
- Before each new outgoing SIP leg, `answer`, `ring_time`, `answer_time`, `hangup_reason`, `ssrc`, and `auto_hangup` are cleared so the new call starts clean.
- Each INVITE gets a unique `Call-ID` (`session_id.random_u32`) — reusing the session ID as Call-ID broke the second invite.

**WebSocket loop in detach mode**
- Uses `join!` instead of `select!` so both the receive and send loops run to completion independently; neither side ending drops the other.
- `recv_from_ws_loop` only breaks on channel error when not in detach mode.

### Tests

Four unit tests in `active_call.rs`:
- `test_detach_hangup_keeps_session_alive` — `do_hangup` cancels `main_call_token`, leaves session token alive, clears state.
- `test_no_detach_hangup_stops_media_stream` — non-detach path cancels media stream.
- `test_detach_make_main_call_token_is_child` — child token cancelled when session cancelled.
- `test_no_detach_make_main_call_token_is_session_token` — non-detach returns session token directly.

Integration test in `handler.rs`:
- `test_call_handler_core_detach_survives_hangup` — spawns `call_handler_core` with `detach=true`, asserts the task is still running after a `Hangup` command, then asserts it terminates cleanly when the command sender is dropped.