### PR TITLE
feat: add refer: bool to Dtmf/Hold events. Add ability to supress dtmf forwarding to/from refered call.

### DIFF
--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -1473,6 +1473,7 @@ impl ActiveCall {
 
         match result {
             Ok(answer) => {
+                self.media_stream.set_track_refer(&track_id, Some(true)).await;
                 self.event_sender
                     .send(SessionEvent::Answer {
                         timestamp: crate::media::get_timestamp(),

--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -1474,6 +1474,10 @@ impl ActiveCall {
         match result {
             Ok(answer) => {
                 self.media_stream.set_track_refer(&track_id, Some(true)).await;
+                let forward_dtmf = refer_option.as_ref().and_then(|o| o.forward_dtmf).unwrap_or(true);
+                if !forward_dtmf {
+                    self.media_stream.set_track_dtmf_forward(&track_id, false).await;
+                }
                 self.event_sender
                     .send(SessionEvent::Answer {
                         timestamp: crate::media::get_timestamp(),

--- a/src/call/sip.rs
+++ b/src/call/sip.rs
@@ -277,10 +277,12 @@ impl DialogStateReceiverGuard {
                     if body_str.starts_with("Signal=") {
                         let digit = body_str.trim_start_matches("Signal=").chars().next();
                         if let Some(digit) = digit {
+                            let is_refer = states.call_state.read().await.is_refer;
                             states.event_sender.send(crate::event::SessionEvent::Dtmf {
                                 track_id: states.track_id.clone(),
                                 timestamp: crate::media::get_timestamp(),
                                 digit: digit.to_string(),
+                                refer: Some(is_refer),
                             })?;
                         }
                     }
@@ -288,6 +290,7 @@ impl DialogStateReceiverGuard {
                 }
                 DialogState::Updated(dialog_id, _req, tx_handle) => {
                     info!(session_id = states.session_id, %dialog_id, "dialog update received");
+                    let is_refer = states.call_state.read().await.is_refer;
                     let mut answer_sdp = None;
                     if let Some(sdp_body) = _req.body().get(..) {
                         let sdp_str = String::from_utf8_lossy(sdp_body);
@@ -322,6 +325,7 @@ impl DialogStateReceiverGuard {
                                     track_id: states.track_id.clone(),
                                     timestamp: crate::media::get_timestamp(),
                                     on_hold: is_on_hold,
+                                    refer: Some(is_refer),
                                 })
                                 .ok();
 
@@ -355,6 +359,7 @@ impl DialogStateReceiverGuard {
                                         track_id: states.track_id.clone(),
                                         timestamp: crate::media::get_timestamp(),
                                         on_hold: true,
+                                        refer: Some(is_refer),
                                     })
                                     .ok();
                             } else {
@@ -368,6 +373,7 @@ impl DialogStateReceiverGuard {
                                         track_id: states.track_id.clone(),
                                         timestamp: crate::media::get_timestamp(),
                                         on_hold: false,
+                                        refer: Some(is_refer),
                                     })
                                     .ok();
                             }

--- a/src/event.rs
+++ b/src/event.rs
@@ -120,11 +120,13 @@ pub enum SessionEvent {
         track_id: String,
         timestamp: u64,
         digit: String,
+        refer: Option<bool>,
     },
     Hold {
         track_id: String,
         timestamp: u64,
         on_hold: bool,
+        refer: Option<bool>,
     },
     TransferRequest {
         track_id: String,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -176,6 +176,8 @@ pub struct ReferOption {
     pub call_id: Option<String>,
     /// Pause parent call's ASR during refer call, will resume after refer ends (if auto_hangup is false)
     pub pause_parent_asr: Option<bool>,
+    /// If false, DTMF RTP packets are not forwarded between the main call and the refer call
+    pub forward_dtmf: Option<bool>,
 }
 
 #[skip_serializing_none]

--- a/src/media/dtmf.rs
+++ b/src/media/dtmf.rs
@@ -22,6 +22,7 @@ pub struct DtmfDetector {
     last_event: AtomicU8,
     last_duration: AtomicU16,
     pub refer: Option<bool>,
+    pub suppress_dtmf_forward: bool,
 }
 
 #[derive(Debug)]
@@ -80,6 +81,7 @@ impl DtmfDetector {
             last_event: AtomicU8::new(0xFF),
             last_duration: AtomicU16::new(0),
             refer: None,
+            suppress_dtmf_forward: false,
         }
     }
 

--- a/src/media/dtmf.rs
+++ b/src/media/dtmf.rs
@@ -21,6 +21,7 @@ pub struct DtmfDetector {
     // Track the last seen event to avoid repeated events
     last_event: AtomicU8,
     last_duration: AtomicU16,
+    pub refer: Option<bool>,
 }
 
 #[derive(Debug)]
@@ -78,6 +79,7 @@ impl DtmfDetector {
         Self {
             last_event: AtomicU8::new(0xFF),
             last_duration: AtomicU16::new(0),
+            refer: None,
         }
     }
 

--- a/src/media/stream.rs
+++ b/src/media/stream.rs
@@ -413,6 +413,12 @@ impl MediaStream {
         }
     }
 
+    pub async fn set_track_dtmf_forward(&self, track_id: &TrackId, forward: bool) {
+        if let Some((_, dtmf)) = self.tracks.lock().await.get_mut(track_id) {
+            dtmf.suppress_dtmf_forward = !forward;
+        }
+    }
+
     async fn handle_forward_track(&self, mut packet_receiver: TrackPacketReceiver) {
         let event_sender = self.event_sender.clone();
         while let Some(packet) = packet_receiver.recv().await {
@@ -422,32 +428,41 @@ impl MediaStream {
                     .await
                     .contains(&packet.track_id)
             };
-            // Process the packet with each track
-            for (track, dtmf_detector) in self.tracks.lock().await.values_mut() {
+
+            let is_dtmf = matches!(&packet.samples,
+                Samples::RTP { payload_type, .. } if *payload_type >= 96 && *payload_type <= 127);
+
+            let mut tracks = self.tracks.lock().await;
+
+            // Check once whether the source track suppresses DTMF forwarding.
+            let source_suppresses_dtmf = is_dtmf
+                && tracks
+                    .get(&packet.track_id)
+                    .map(|(_, d)| d.suppress_dtmf_forward)
+                    .unwrap_or(false);
+
+            for (track, dtmf_detector) in tracks.values_mut() {
                 if track.id() == &packet.track_id {
-                    match &packet.samples {
-                        Samples::RTP {
-                            payload_type,
-                            payload,
-                            ..
-                        } => {
-                            if let Some(digit) = dtmf_detector.detect_rtp(*payload_type, payload) {
-                                debug!(track_id = track.id(), digit, "DTMF detected");
-                                event_sender
-                                    .send(SessionEvent::Dtmf {
-                                        track_id: packet.track_id.to_string(),
-                                        timestamp: packet.timestamp,
-                                        digit,
-                                        refer: dtmf_detector.refer,
-                                    })
-                                    .ok();
-                            }
+                    if let Samples::RTP { payload_type, payload, .. } = &packet.samples {
+                        if let Some(digit) = dtmf_detector.detect_rtp(*payload_type, payload) {
+                            debug!(track_id = track.id(), digit, "DTMF detected");
+                            event_sender
+                                .send(SessionEvent::Dtmf {
+                                    track_id: packet.track_id.to_string(),
+                                    timestamp: packet.timestamp,
+                                    digit,
+                                    refer: dtmf_detector.refer,
+                                })
+                                .ok();
                         }
-                        _ => {}
                     }
                     continue;
                 }
                 if suppressed {
+                    continue;
+                }
+                // Skip DTMF forwarding if source or destination has it suppressed.
+                if source_suppresses_dtmf || (is_dtmf && dtmf_detector.suppress_dtmf_forward) {
                     continue;
                 }
                 if packet.track_id == QUEUE_HOLD_TRACK_ID && track.id() == CALLEE_TRACK_ID {

--- a/src/media/stream.rs
+++ b/src/media/stream.rs
@@ -407,6 +407,12 @@ impl MediaStream {
         Ok(())
     }
 
+    pub async fn set_track_refer(&self, track_id: &TrackId, refer: Option<bool>) {
+        if let Some((_, dtmf)) = self.tracks.lock().await.get_mut(track_id) {
+            dtmf.refer = refer;
+        }
+    }
+
     async fn handle_forward_track(&self, mut packet_receiver: TrackPacketReceiver) {
         let event_sender = self.event_sender.clone();
         while let Some(packet) = packet_receiver.recv().await {
@@ -432,6 +438,7 @@ impl MediaStream {
                                         track_id: packet.track_id.to_string(),
                                         timestamp: packet.timestamp,
                                         digit,
+                                        refer: dtmf_detector.refer,
                                     })
                                     .ok();
                             }

--- a/src/playbook/handler/dtmf_collector_tests.rs
+++ b/src/playbook/handler/dtmf_collector_tests.rs
@@ -428,6 +428,7 @@ async fn test_collector_on_event_dtmf_routing() -> Result<()> {
         digit: "5".to_string(),
         track_id: "test-track".to_string(),
         timestamp: crate::media::get_timestamp(),
+        refer: None,
     };
 
     let _commands = handler.on_event(&event).await?;

--- a/tests/asr_pause_resume_test.rs
+++ b/tests/asr_pause_resume_test.rs
@@ -32,6 +32,7 @@ async fn test_refer_option_pause_parent_asr_field() {
         asr: None,
         sip: None,
         call_id: None,
+        forward_dtmf: None,
     };
 
     assert_eq!(refer_option.pause_parent_asr, Some(true));
@@ -45,6 +46,7 @@ async fn test_refer_option_pause_parent_asr_field() {
         asr: None,
         sip: None,
         call_id: None,
+        forward_dtmf: None,
     };
 
     assert_eq!(refer_option_false.pause_parent_asr, Some(false));
@@ -59,6 +61,7 @@ async fn test_refer_option_pause_parent_asr_field() {
         asr: None,
         sip: None,
         call_id: None,
+        forward_dtmf: None,
     };
     assert_eq!(none_refer.pause_parent_asr, None);
 }
@@ -135,6 +138,7 @@ async fn test_refer_option_serialization() -> Result<()> {
         asr: None,
         sip: None,
         call_id: None,
+        forward_dtmf: None,
     };
 
     let json = serde_json::to_string(&refer_option)?;


### PR DESCRIPTION
1. Distinguish DTMF/HOLD between main/refer call.
2. Add option to skip DTMF beeps between call legs - events are still emitted. 