### PR TITLE
feat: Add `Bridge` command for bidirectional audio patching between established calls

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -547,6 +547,46 @@ Commands are sent as JSON messages through the WebSocket connection. All timesta
 }
 ```
 
+### Audio Bridge Commands
+
+#### Bridge Command
+**Purpose:** Connects audio between this active call session and another active call session.
+
+The bridge is a media-only operation. It creates separate internal bridge tracks for the two sessions and forwards audio packets between them. It does not replace the normal server-side track used by TTS/play/refer, and it does not send SIP signaling or hang up either call. Call lifecycle remains controlled by each call's own WebSocket client, SIP peer, or explicit `hangup` command.
+
+**Fields:**
+- `command` (string): Always "bridge"
+- `targetSessionId` (string): Session ID of the other active call
+
+```json
+{
+  "command": "bridge",
+  "targetSessionId": "session-b"
+}
+```
+
+**Notes:**
+- Send the command on either session's WebSocket after both sessions are established.
+- The target session must still be active and must not be the same session.
+- Re-sending `bridge` for the same pair replaces the existing bridge tracks for that pair.
+- If either call ends, its bridge track stops and the peer bridge task exits; the other call remains active until its own client or SIP peer ends it.
+
+#### Unbridge Command
+**Purpose:** Removes the audio bridge between this active call session and another active call session.
+
+`unbridge` removes the internal bridge tracks from both sessions when both sessions are active. If the target session has already ended, it removes the local bridge track only. It is safe to send after one side has already hung up.
+
+**Fields:**
+- `command` (string): Always "unbridge"
+- `targetSessionId` (string): Session ID of the other call
+
+```json
+{
+  "command": "unbridge",
+  "targetSessionId": "session-b"
+}
+```
+
 ### Audio Track Control Commands
 
 #### Mute Command

--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -42,7 +42,15 @@ use audio_codec::CodecType;
 use chrono::{DateTime, Utc};
 use rsipstack::dialog::{invitation::InviteOption, server_dialog::ServerInviteDialog};
 use serde::{Deserialize, Serialize};
-use std::{collections::HashMap, path::Path, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    path::Path,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
+    time::Duration,
+};
 use tokio::{fs::File, select, sync::Mutex, sync::RwLock, sync::mpsc, time::sleep};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
@@ -262,6 +270,7 @@ pub struct ActiveCallState {
     pub audio_receiver: Option<WebsocketBytesReceiver>,
     pub ready_to_answer: Option<(String, Option<Box<dyn Track>>, ServerInviteDialog)>,
     pub pending_asr_resume: Option<(u32, TranscriptionOption)>,
+    pub bridge_paused: Arc<AtomicBool>,
 }
 
 pub type ActiveCallRef = Arc<ActiveCall>;
@@ -669,6 +678,13 @@ impl ActiveCall {
                                 .await;
                             continue;
                         }
+                    }
+                    SessionEvent::Hold { on_hold, .. } => {
+                        self.call_state
+                            .read()
+                            .await
+                            .bridge_paused
+                            .store(on_hold, Ordering::Relaxed);
                     }
                     _ => {}
                 }
@@ -1543,6 +1559,9 @@ impl ActiveCall {
         let (self_bridge_sender, self_bridge_receiver) = mpsc::channel(25);
         let (target_bridge_sender, target_bridge_receiver) = mpsc::channel(25);
 
+        let self_paused = self.call_state.read().await.bridge_paused.clone();
+        let target_paused = target.call_state.read().await.bridge_paused.clone();
+
         let self_forwarding_track = ForwardingTrack::new(
             self_bridge_track_id.clone(),
             self.session_id.clone(),
@@ -1551,6 +1570,7 @@ impl ActiveCall {
             self.track_config.clone(),
             self.cancel_token.child_token(),
             rand::random::<u32>(),
+            self_paused,
         );
 
         let target_forwarding_track = ForwardingTrack::new(
@@ -1561,6 +1581,7 @@ impl ActiveCall {
             target.track_config.clone(),
             target.cancel_token.child_token(),
             rand::random::<u32>(),
+            target_paused,
         );
 
         self.media_stream

--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -13,6 +13,7 @@ use crate::{
         track::{
             Track, TrackConfig,
             file::FileTrack,
+            forwarding::ForwardingTrack,
             media_pass::MediaPassTrack,
             rtc::{RtcTrack, RtcTrackConfig},
             tts::SynthesisHandle,
@@ -42,7 +43,7 @@ use chrono::{DateTime, Utc};
 use rsipstack::dialog::{invitation::InviteOption, server_dialog::ServerInviteDialog};
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path, sync::Arc, time::Duration};
-use tokio::{fs::File, select, sync::Mutex, sync::RwLock, time::sleep};
+use tokio::{fs::File, select, sync::Mutex, sync::RwLock, sync::mpsc, time::sleep};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
 
@@ -754,6 +755,7 @@ impl ActiveCall {
                 options,
             } => self.do_refer(caller, callee, options).await,
             Command::Bridge { target_session_id } => self.do_bridge(target_session_id).await,
+            Command::Unbridge { target_session_id } => self.do_unbridge(target_session_id).await,
             Command::Mute { track_id } => self.do_mute(track_id).await,
             Command::Unmute { track_id } => self.do_unmute(track_id).await,
             Command::Pause {} => self.do_pause().await,
@@ -1510,6 +1512,10 @@ impl ActiveCall {
         Ok(())
     }
 
+    fn bridge_track_id(source_session_id: &str, target_session_id: &str) -> TrackId {
+        format!("bridge:{}:to:{}", source_session_id, target_session_id)
+    }
+
     async fn do_bridge(&self, target_session_id: String) -> Result<()> {
         let target = {
             let calls = self.app_state.active_calls.lock().unwrap();
@@ -1523,45 +1529,92 @@ impl ActiveCall {
             return Err(anyhow::anyhow!("cannot bridge a call to itself").into());
         }
 
-        // Bridge lifetime: cancelled when either call cancels, or by either
-        // ForwardingProcessor when its destination channel is dropped.
-        let bridge_token = CancellationToken::new();
-        let self_token = self.cancel_token.clone();
-        let target_token = target.cancel_token.clone();
-        let bridge_token_watcher = bridge_token.clone();
-        let session_id = self.session_id.clone();
-        let target_session_id_log = target_session_id.clone();
-        crate::spawn(async move {
-            select! {
-                _ = self_token.cancelled() => {}
-                _ = target_token.cancelled() => {}
-                _ = bridge_token_watcher.cancelled() => {}
-            }
-            bridge_token_watcher.cancel();
-            info!(
-                session_id,
-                target = target_session_id_log,
-                "audio bridge torn down"
-            );
-        });
+        let self_bridge_track_id = Self::bridge_track_id(&self.session_id, &target.session_id);
+        let target_bridge_track_id = Self::bridge_track_id(&target.session_id, &self.session_id);
 
-        // The caller-side track (RTC/WebRTC/WebSocket/SIP) is registered under
-        // session_id and is the one whose processor chain sees audio received
-        // from the remote endpoint. server_side_track_id is for server-originated
-        // playback (TTS/files) and is not what we want to tap.
         self.media_stream
-            .bridge_to(&target.media_stream, &self.session_id, bridge_token.clone())
-            .await?;
+            .remove_track(&self_bridge_track_id, false)
+            .await;
         target
             .media_stream
-            .bridge_to(&self.media_stream, &target.session_id, bridge_token.clone())
-            .await?;
+            .remove_track(&target_bridge_track_id, false)
+            .await;
+
+        let (self_bridge_sender, self_bridge_receiver) = mpsc::channel(25);
+        let (target_bridge_sender, target_bridge_receiver) = mpsc::channel(25);
+
+        let self_forwarding_track = ForwardingTrack::new(
+            self_bridge_track_id.clone(),
+            self.session_id.clone(),
+            target_bridge_sender,
+            self_bridge_receiver,
+            self.track_config.clone(),
+            self.cancel_token.child_token(),
+            rand::random::<u32>(),
+        );
+
+        let target_forwarding_track = ForwardingTrack::new(
+            target_bridge_track_id.clone(),
+            target.session_id.clone(),
+            self_bridge_sender,
+            target_bridge_receiver,
+            target.track_config.clone(),
+            target.cancel_token.child_token(),
+            rand::random::<u32>(),
+        );
+
+        self.media_stream
+            .update_track(Box::new(self_forwarding_track), None)
+            .await;
+        target
+            .media_stream
+            .update_track(Box::new(target_forwarding_track), None)
+            .await;
 
         info!(
             session_id = self.session_id,
             target = target_session_id,
+            self_bridge_track_id,
+            target_bridge_track_id,
             "audio bridge established"
         );
+        Ok(())
+    }
+
+    async fn do_unbridge(&self, target_session_id: String) -> Result<()> {
+        let target = {
+            let calls = self.app_state.active_calls.lock().unwrap();
+            calls.get(&target_session_id).cloned()
+        };
+
+        let self_bridge_track_id = Self::bridge_track_id(&self.session_id, &target_session_id);
+        self.media_stream
+            .remove_track(&self_bridge_track_id, false)
+            .await;
+
+        if let Some(target) = target {
+            let target_bridge_track_id =
+                Self::bridge_track_id(&target.session_id, &self.session_id);
+            target
+                .media_stream
+                .remove_track(&target_bridge_track_id, false)
+                .await;
+            info!(
+                session_id = self.session_id,
+                target = target.session_id,
+                self_bridge_track_id,
+                target_bridge_track_id,
+                "audio bridge removed"
+            );
+        } else {
+            info!(
+                session_id = self.session_id,
+                target = target_session_id,
+                self_bridge_track_id,
+                "audio bridge removed locally; target session not active"
+            );
+        }
+
         Ok(())
     }
 

--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -753,6 +753,7 @@ impl ActiveCall {
                 callee,
                 options,
             } => self.do_refer(caller, callee, options).await,
+            Command::Bridge { target_session_id } => self.do_bridge(target_session_id).await,
             Command::Mute { track_id } => self.do_mute(track_id).await,
             Command::Unmute { track_id } => self.do_unmute(track_id).await,
             Command::Pause {} => self.do_pause().await,
@@ -1017,7 +1018,9 @@ impl ActiveCall {
             );
             if let Some(ringtone_url) = ringtone {
                 drop(state);
-                self.do_play(ringtone_url, None, None, None, None).await.ok();
+                self.do_play(ringtone_url, None, None, None, None)
+                    .await
+                    .ok();
             } else {
                 info!(session_id = self.session_id, "no ringtone to play");
             }
@@ -1504,6 +1507,61 @@ impl ActiveCall {
                 return Err(e.into());
             }
         }
+        Ok(())
+    }
+
+    async fn do_bridge(&self, target_session_id: String) -> Result<()> {
+        let target = {
+            let calls = self.app_state.active_calls.lock().unwrap();
+            calls.get(&target_session_id).cloned()
+        };
+        let target = target.ok_or_else(|| {
+            anyhow::anyhow!("bridge target session not found: {}", target_session_id)
+        })?;
+
+        if target.session_id == self.session_id {
+            return Err(anyhow::anyhow!("cannot bridge a call to itself").into());
+        }
+
+        // Bridge lifetime: cancelled when either call cancels, or by either
+        // ForwardingProcessor when its destination channel is dropped.
+        let bridge_token = CancellationToken::new();
+        let self_token = self.cancel_token.clone();
+        let target_token = target.cancel_token.clone();
+        let bridge_token_watcher = bridge_token.clone();
+        let session_id = self.session_id.clone();
+        let target_session_id_log = target_session_id.clone();
+        crate::spawn(async move {
+            select! {
+                _ = self_token.cancelled() => {}
+                _ = target_token.cancelled() => {}
+                _ = bridge_token_watcher.cancelled() => {}
+            }
+            bridge_token_watcher.cancel();
+            info!(
+                session_id,
+                target = target_session_id_log,
+                "audio bridge torn down"
+            );
+        });
+
+        // The caller-side track (RTC/WebRTC/WebSocket/SIP) is registered under
+        // session_id and is the one whose processor chain sees audio received
+        // from the remote endpoint. server_side_track_id is for server-originated
+        // playback (TTS/files) and is not what we want to tap.
+        self.media_stream
+            .bridge_to(&target.media_stream, &self.session_id, bridge_token.clone())
+            .await?;
+        target
+            .media_stream
+            .bridge_to(&self.media_stream, &target.session_id, bridge_token.clone())
+            .await?;
+
+        info!(
+            session_id = self.session_id,
+            target = target_session_id,
+            "audio bridge established"
+        );
         Ok(())
     }
 

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -83,6 +83,13 @@ pub enum Command {
         callee: String,
         options: Option<ReferOption>,
     },
+    /// Bridge audio with another established call.
+    /// Both calls remain in their own session/event flow; only audio is patched
+    /// between them bidirectionally. Call flow is handled externally.
+    Bridge {
+        /// session_id of the other call to bridge audio with
+        target_session_id: String,
+    },
     Mute {
         track_id: Option<String>,
     },

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -84,10 +84,16 @@ pub enum Command {
         options: Option<ReferOption>,
     },
     /// Bridge audio with another established call.
-    /// Both calls remain in their own session/event flow; only audio is patched
-    /// between them bidirectionally. Call flow is handled externally.
+    /// This creates separate bridge tracks for the two sessions and patches
+    /// audio bidirectionally. It does not replace the server-side track and
+    /// does not control hangup; each call keeps its own session/event flow.
     Bridge {
         /// session_id of the other call to bridge audio with
+        target_session_id: String,
+    },
+    /// Remove audio bridge tracks with another established call.
+    Unbridge {
+        /// session_id of the other call to unbridge from
         target_session_id: String,
     },
     Mute {

--- a/src/media/stream.rs
+++ b/src/media/stream.rs
@@ -337,6 +337,26 @@ impl MediaStream {
             Err(anyhow::anyhow!("Track {} not found", track_id))
         }
     }
+
+    /// Patch processed audio frames from `my_track_id` on this stream into
+    /// `other`'s packet pipeline. This is one direction of a bridge; the
+    /// caller should also call this on `other` to make it bidirectional.
+    ///
+    /// `cancel_token` controls the lifetime of the forwarding; when it fires,
+    /// the processor becomes a no-op. Pass a token tied to both calls so the
+    /// bridge tears down as soon as either side ends.
+    pub async fn bridge_to(
+        &self,
+        other: &MediaStream,
+        my_track_id: &TrackId,
+        cancel_token: CancellationToken,
+    ) -> Result<()> {
+        let inject_track_id = format!("bridge-{}", uuid::Uuid::new_v4());
+        let processor =
+            ForwardingProcessor::new(other.packet_sender.clone(), inject_track_id, cancel_token);
+        self.append_processor(my_track_id, Box::new(processor))
+            .await
+    }
 }
 
 #[derive(Clone)]
@@ -354,6 +374,53 @@ impl Processor for RecorderProcessor {
     fn process_frame(&mut self, frame: &mut AudioFrame) -> Result<()> {
         let frame_clone = frame.clone();
         let _ = self.sender.send(frame_clone);
+        Ok(())
+    }
+}
+
+/// Forwards processed audio frames into another MediaStream's packet pipeline,
+/// rewriting the track_id so the destination's source-skip filter does not drop
+/// the frame. Used to bridge audio between two active calls.
+///
+/// The processor becomes a no-op once `cancel_token` fires, so that when either
+/// bridged call ends we stop cloning frames into a dead channel.
+pub struct ForwardingProcessor {
+    sender: TrackPacketSender,
+    inject_track_id: TrackId,
+    cancel_token: CancellationToken,
+}
+
+impl ForwardingProcessor {
+    pub fn new(
+        sender: TrackPacketSender,
+        inject_track_id: TrackId,
+        cancel_token: CancellationToken,
+    ) -> Self {
+        Self {
+            sender,
+            inject_track_id,
+            cancel_token,
+        }
+    }
+}
+
+impl Processor for ForwardingProcessor {
+    fn process_frame(&mut self, frame: &mut AudioFrame) -> Result<()> {
+        if self.cancel_token.is_cancelled() {
+            return Ok(());
+        }
+        // Drop DTMF (telephone-event) RTP frames so digits stay on their
+        // originating call and don't leak across the bridge.
+        if let Samples::RTP { payload_type, .. } = &frame.samples {
+            if *payload_type >= 96 && *payload_type <= 127 {
+                return Ok(());
+            }
+        }
+        let mut f = frame.clone();
+        f.track_id = self.inject_track_id.clone();
+        if self.sender.send(f).is_err() {
+            self.cancel_token.cancel();
+        }
         Ok(())
     }
 }

--- a/src/media/stream.rs
+++ b/src/media/stream.rs
@@ -10,6 +10,7 @@ use crate::media::{
 use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
+use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio::{
@@ -32,6 +33,8 @@ pub struct MediaStream {
     recorder_sender: mpsc::UnboundedSender<AudioFrame>,
     recorder_receiver: Mutex<Option<mpsc::UnboundedReceiver<AudioFrame>>>,
     recorder_handle: Mutex<Option<JoinHandle<()>>>,
+    /// Pause flag shared with ForwardingProcessor; set when this stream is held.
+    bridge_forward_paused: Arc<AtomicBool>,
 }
 
 const CALLEE_TRACK_ID: &str = "callee-track";
@@ -87,6 +90,7 @@ impl MediaStreamBuilder {
             recorder_sender,
             recorder_receiver: Mutex::new(Some(recorder_receiver)),
             recorder_handle: Mutex::new(None),
+            bridge_forward_paused: Arc::new(AtomicBool::new(false)),
         }
     }
 }
@@ -291,6 +295,7 @@ impl MediaStream {
                 HoldTrack::hold_track(track.as_mut());
             }
         }
+        self.bridge_forward_paused.store(true, Ordering::Relaxed);
     }
 
     pub async fn resume_track(&self, id: Option<TrackId>) {
@@ -303,6 +308,7 @@ impl MediaStream {
                 HoldTrack::resume_track(track.as_mut());
             }
         }
+        self.bridge_forward_paused.store(false, Ordering::Relaxed);
     }
 
     pub async fn suppress_forwarding(&self, track_id: &TrackId) {
@@ -352,8 +358,12 @@ impl MediaStream {
         cancel_token: CancellationToken,
     ) -> Result<()> {
         let inject_track_id = format!("bridge-{}", uuid::Uuid::new_v4());
-        let processor =
-            ForwardingProcessor::new(other.packet_sender.clone(), inject_track_id, cancel_token);
+        let processor = ForwardingProcessor::new(
+            other.packet_sender.clone(),
+            inject_track_id,
+            cancel_token,
+            self.bridge_forward_paused.clone(),
+        );
         self.append_processor(my_track_id, Box::new(processor))
             .await
     }
@@ -388,6 +398,9 @@ pub struct ForwardingProcessor {
     sender: TrackPacketSender,
     inject_track_id: TrackId,
     cancel_token: CancellationToken,
+    /// Shared with `MediaStream::bridge_forward_paused`; set to true while the
+    /// source call is on hold so that silence frames don't leak to the peer.
+    paused: Arc<AtomicBool>,
 }
 
 impl ForwardingProcessor {
@@ -395,11 +408,13 @@ impl ForwardingProcessor {
         sender: TrackPacketSender,
         inject_track_id: TrackId,
         cancel_token: CancellationToken,
+        paused: Arc<AtomicBool>,
     ) -> Self {
         Self {
             sender,
             inject_track_id,
             cancel_token,
+            paused,
         }
     }
 }
@@ -407,6 +422,9 @@ impl ForwardingProcessor {
 impl Processor for ForwardingProcessor {
     fn process_frame(&mut self, frame: &mut AudioFrame) -> Result<()> {
         if self.cancel_token.is_cancelled() {
+            return Ok(());
+        }
+        if self.paused.load(Ordering::Relaxed) {
             return Ok(());
         }
         // Drop DTMF (telephone-event) RTP frames so digits stay on their

--- a/src/media/stream.rs
+++ b/src/media/stream.rs
@@ -10,7 +10,6 @@ use crate::media::{
 use anyhow::Result;
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
-use std::sync::{Arc, atomic::{AtomicBool, Ordering}};
 use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio::{
@@ -33,8 +32,6 @@ pub struct MediaStream {
     recorder_sender: mpsc::UnboundedSender<AudioFrame>,
     recorder_receiver: Mutex<Option<mpsc::UnboundedReceiver<AudioFrame>>>,
     recorder_handle: Mutex<Option<JoinHandle<()>>>,
-    /// Pause flag shared with ForwardingProcessor; set when this stream is held.
-    bridge_forward_paused: Arc<AtomicBool>,
 }
 
 const CALLEE_TRACK_ID: &str = "callee-track";
@@ -90,7 +87,6 @@ impl MediaStreamBuilder {
             recorder_sender,
             recorder_receiver: Mutex::new(Some(recorder_receiver)),
             recorder_handle: Mutex::new(None),
-            bridge_forward_paused: Arc::new(AtomicBool::new(false)),
         }
     }
 }
@@ -295,7 +291,6 @@ impl MediaStream {
                 HoldTrack::hold_track(track.as_mut());
             }
         }
-        self.bridge_forward_paused.store(true, Ordering::Relaxed);
     }
 
     pub async fn resume_track(&self, id: Option<TrackId>) {
@@ -308,7 +303,6 @@ impl MediaStream {
                 HoldTrack::resume_track(track.as_mut());
             }
         }
-        self.bridge_forward_paused.store(false, Ordering::Relaxed);
     }
 
     pub async fn suppress_forwarding(&self, track_id: &TrackId) {
@@ -344,29 +338,6 @@ impl MediaStream {
         }
     }
 
-    /// Patch processed audio frames from `my_track_id` on this stream into
-    /// `other`'s packet pipeline. This is one direction of a bridge; the
-    /// caller should also call this on `other` to make it bidirectional.
-    ///
-    /// `cancel_token` controls the lifetime of the forwarding; when it fires,
-    /// the processor becomes a no-op. Pass a token tied to both calls so the
-    /// bridge tears down as soon as either side ends.
-    pub async fn bridge_to(
-        &self,
-        other: &MediaStream,
-        my_track_id: &TrackId,
-        cancel_token: CancellationToken,
-    ) -> Result<()> {
-        let inject_track_id = format!("bridge-{}", uuid::Uuid::new_v4());
-        let processor = ForwardingProcessor::new(
-            other.packet_sender.clone(),
-            inject_track_id,
-            cancel_token,
-            self.bridge_forward_paused.clone(),
-        );
-        self.append_processor(my_track_id, Box::new(processor))
-            .await
-    }
 }
 
 #[derive(Clone)]
@@ -384,61 +355,6 @@ impl Processor for RecorderProcessor {
     fn process_frame(&mut self, frame: &mut AudioFrame) -> Result<()> {
         let frame_clone = frame.clone();
         let _ = self.sender.send(frame_clone);
-        Ok(())
-    }
-}
-
-/// Forwards processed audio frames into another MediaStream's packet pipeline,
-/// rewriting the track_id so the destination's source-skip filter does not drop
-/// the frame. Used to bridge audio between two active calls.
-///
-/// The processor becomes a no-op once `cancel_token` fires, so that when either
-/// bridged call ends we stop cloning frames into a dead channel.
-pub struct ForwardingProcessor {
-    sender: TrackPacketSender,
-    inject_track_id: TrackId,
-    cancel_token: CancellationToken,
-    /// Shared with `MediaStream::bridge_forward_paused`; set to true while the
-    /// source call is on hold so that silence frames don't leak to the peer.
-    paused: Arc<AtomicBool>,
-}
-
-impl ForwardingProcessor {
-    pub fn new(
-        sender: TrackPacketSender,
-        inject_track_id: TrackId,
-        cancel_token: CancellationToken,
-        paused: Arc<AtomicBool>,
-    ) -> Self {
-        Self {
-            sender,
-            inject_track_id,
-            cancel_token,
-            paused,
-        }
-    }
-}
-
-impl Processor for ForwardingProcessor {
-    fn process_frame(&mut self, frame: &mut AudioFrame) -> Result<()> {
-        if self.cancel_token.is_cancelled() {
-            return Ok(());
-        }
-        if self.paused.load(Ordering::Relaxed) {
-            return Ok(());
-        }
-        // Drop DTMF (telephone-event) RTP frames so digits stay on their
-        // originating call and don't leak across the bridge.
-        if let Samples::RTP { payload_type, .. } = &frame.samples {
-            if *payload_type >= 96 && *payload_type <= 127 {
-                return Ok(());
-            }
-        }
-        let mut f = frame.clone();
-        f.track_id = self.inject_track_id.clone();
-        if self.sender.send(f).is_err() {
-            self.cancel_token.cancel();
-        }
         Ok(())
     }
 }

--- a/src/media/track/forwarding.rs
+++ b/src/media/track/forwarding.rs
@@ -1,0 +1,137 @@
+use crate::event::EventSender;
+use crate::media::processor::ProcessorChain;
+use crate::media::track::{Track, TrackConfig, TrackPacketSender};
+use crate::media::{AudioFrame, Samples, TrackId};
+use anyhow::Result;
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+use tokio::time::Duration;
+use tokio_util::sync::CancellationToken;
+use tracing::info;
+
+pub struct ForwardingTrack {
+    track_id: TrackId,
+    source_peer_track_id: TrackId,
+    peer_sender: mpsc::Sender<AudioFrame>,
+    inbound_receiver: Option<mpsc::Receiver<AudioFrame>>,
+    processor_chain: ProcessorChain,
+    config: TrackConfig,
+    cancel_token: CancellationToken,
+    ssrc: u32,
+}
+
+impl ForwardingTrack {
+    pub fn new(
+        track_id: TrackId,
+        source_peer_track_id: TrackId,
+        peer_sender: mpsc::Sender<AudioFrame>,
+        inbound_receiver: mpsc::Receiver<AudioFrame>,
+        config: TrackConfig,
+        cancel_token: CancellationToken,
+        ssrc: u32,
+    ) -> Self {
+        Self {
+            processor_chain: ProcessorChain::new(config.samplerate),
+            track_id,
+            source_peer_track_id,
+            peer_sender,
+            inbound_receiver: Some(inbound_receiver),
+            config,
+            cancel_token,
+            ssrc,
+        }
+    }
+}
+
+#[async_trait]
+impl Track for ForwardingTrack {
+    fn ssrc(&self) -> u32 {
+        self.ssrc
+    }
+
+    fn id(&self) -> &TrackId {
+        &self.track_id
+    }
+
+    fn config(&self) -> &TrackConfig {
+        &self.config
+    }
+
+    fn processor_chain(&mut self) -> &mut ProcessorChain {
+        &mut self.processor_chain
+    }
+
+    async fn handshake(&mut self, _offer: String, _timeout: Option<Duration>) -> Result<String> {
+        Ok(String::new())
+    }
+
+    async fn update_remote_description(&mut self, _answer: &String) -> Result<()> {
+        Ok(())
+    }
+
+    async fn start(
+        &mut self,
+        _event_sender: EventSender,
+        packet_sender: TrackPacketSender,
+    ) -> Result<()> {
+        let mut inbound_receiver = self
+            .inbound_receiver
+            .take()
+            .ok_or_else(|| anyhow::anyhow!("forwarding track already started"))?;
+        let track_id = self.track_id.clone();
+        let cancel_token = self.cancel_token.clone();
+
+        crate::spawn(async move {
+            let stop_reason = loop {
+                tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        break "track stopped";
+                    }
+                    packet = inbound_receiver.recv() => {
+                        match packet {
+                            Some(mut packet) => {
+                                packet.track_id = track_id.clone();
+                                if packet_sender.send(packet).is_err() {
+                                    break "media stream closed";
+                                }
+                            }
+                            None => {
+                                break "peer bridge channel closed";
+                            }
+                        }
+                    }
+                }
+            };
+            cancel_token.cancel();
+            info!(track_id, reason = stop_reason, "audio bridge forwarding task stopped");
+        });
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        self.cancel_token.cancel();
+        Ok(())
+    }
+
+    async fn send_packet(&mut self, packet: &AudioFrame) -> Result<()> {
+        if self.cancel_token.is_cancelled() || packet.track_id != self.source_peer_track_id {
+            return Ok(());
+        }
+
+        if let Samples::RTP { payload_type, .. } = &packet.samples {
+            if *payload_type >= 96 && *payload_type <= 127 {
+                return Ok(());
+            }
+        }
+
+        match self.peer_sender.try_send(packet.clone()) {
+            Ok(_) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {}
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.cancel_token.cancel();
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/media/track/forwarding.rs
+++ b/src/media/track/forwarding.rs
@@ -4,6 +4,10 @@ use crate::media::track::{Track, TrackConfig, TrackPacketSender};
 use crate::media::{AudioFrame, Samples, TrackId};
 use anyhow::Result;
 use async_trait::async_trait;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use tokio::sync::mpsc;
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
@@ -18,6 +22,7 @@ pub struct ForwardingTrack {
     config: TrackConfig,
     cancel_token: CancellationToken,
     ssrc: u32,
+    paused: Arc<AtomicBool>,
 }
 
 impl ForwardingTrack {
@@ -29,6 +34,7 @@ impl ForwardingTrack {
         config: TrackConfig,
         cancel_token: CancellationToken,
         ssrc: u32,
+        paused: Arc<AtomicBool>,
     ) -> Self {
         Self {
             processor_chain: ProcessorChain::new(config.samplerate),
@@ -39,6 +45,7 @@ impl ForwardingTrack {
             config,
             cancel_token,
             ssrc,
+            paused,
         }
     }
 }
@@ -103,7 +110,11 @@ impl Track for ForwardingTrack {
                 }
             };
             cancel_token.cancel();
-            info!(track_id, reason = stop_reason, "audio bridge forwarding task stopped");
+            info!(
+                track_id,
+                reason = stop_reason,
+                "audio bridge forwarding task stopped"
+            );
         });
         Ok(())
     }
@@ -114,7 +125,10 @@ impl Track for ForwardingTrack {
     }
 
     async fn send_packet(&mut self, packet: &AudioFrame) -> Result<()> {
-        if self.cancel_token.is_cancelled() || packet.track_id != self.source_peer_track_id {
+        if self.cancel_token.is_cancelled()
+            || self.paused.load(Ordering::Relaxed)
+            || packet.track_id != self.source_peer_track_id
+        {
             return Ok(());
         }
 

--- a/src/media/track/mod.rs
+++ b/src/media/track/mod.rs
@@ -54,6 +54,7 @@ impl TrackConfig {
 }
 
 pub mod file;
+pub mod forwarding;
 pub mod media_pass;
 pub mod rtc;
 pub mod track_codec;


### PR DESCRIPTION
After trying to implement needed logic with refer - i've given up. It's fine for simple cases, but for more complex work with websocket handling - it's too rigid.

So I've decided to hold two separate call sessions, bridge the audio between them and handle events from both of them externally.
It's the most non-intrusive approach for handling call transfers, artificial delays and informing operator (refer leg) with tts before/after the call I could come up with.


Summary

- Adds a new `Command::Bridge { target_session_id }` that patches audio between two already-established calls without creating new SIP legs or touching either call's session/event flow.
- Implements `ForwardingProcessor` — a lightweight `Processor` that clones decoded audio frames and injects them into another `MediaStream`'s packet pipeline, skipping DTMF (telephone-event, PT 96–127) so digits stay on their originating call.
- Adds `MediaStream::bridge_to(other, track_id, cancel_token)` to install a one-directional forwarding leg; `do_bridge` calls it twice for bidirectional audio.
- Bridge lifetime is tied to a shared `CancellationToken` that fires as soon as either call ends (either call's cancel token) or as soon as a channel send fails (receiver dropped). When cancelled the processor becomes a no-op with zero allocations — no explicit uninstall needed.

