### PR TITLE
feat: allow specifiyin enable_ice_lite in CallOptions

### DIFF
--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -1943,7 +1943,14 @@ impl ActiveCall {
         }
 
         rtc_config.enable_latching = self.app_state.config.enable_rtp_latching;
-        rtc_config.enable_ice_lite = self.app_state.config.enable_ice_lite;
+        rtc_config.enable_ice_lite = self
+            .call_state
+            .read()
+            .await
+            .option
+            .as_ref()
+            .and_then(|o| o.enable_ice_lite)
+            .or(self.app_state.config.enable_ice_lite);
 
         let mut track = RtcTrack::new(
             self.cancel_token.child_token(),
@@ -2618,7 +2625,14 @@ impl ActiveCall {
                 rtc_config.bind_ip = Some(bind_ip.clone());
             }
             rtc_config.enable_latching = self.app_state.config.enable_rtp_latching;
-            rtc_config.enable_ice_lite = self.app_state.config.enable_ice_lite;
+            rtc_config.enable_ice_lite = self
+                .call_state
+                .read()
+                .await
+                .option
+                .as_ref()
+                .and_then(|o| o.enable_ice_lite)
+                .or(self.app_state.config.enable_ice_lite);
 
             let webrtc_track = RtcTrack::new(
                 self.cancel_token.child_token(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,6 +69,7 @@ pub struct CallOption {
     pub eou: Option<EouOption>,
     pub realtime: Option<RealtimeOption>,
     pub subscribe: Option<bool>,
+    pub enable_ice_lite: Option<bool>,
 }
 
 impl Default for CallOption {
@@ -93,6 +94,7 @@ impl Default for CallOption {
             eou: None,
             realtime: None,
             subscribe: None,
+            enable_ice_lite: None,
         }
     }
 }


### PR DESCRIPTION
I've tried calling into voximplant platform using sip, but with enable_ice_lite audio doesn't come through. But I need that enabled for other calls. I've tested that setting enable_ice_lite=false fixes audio problem.

This PR allows to specify enable_ice_lite using CallOptions

If needed, please leave a comment, I can provide call logs for reproducer, so that root cause could be fixed.