### PR TITLE
fix: ForwardingTrack skips processor chain, so audio from bridged cal…

### DIFF
--- a/src/media/recorder.rs
+++ b/src/media/recorder.rs
@@ -351,6 +351,9 @@ impl Recorder {
     }
 
     fn get_channel_index(&self, track_id: &str) -> usize {
+        if track_id.starts_with("bridge:") {
+            return 1;
+        }
         let mut channels = self.channels.lock().unwrap();
         if let Some(&channel_idx) = channels.get(track_id) {
             channel_idx % 2

--- a/src/media/track/forwarding.rs
+++ b/src/media/track/forwarding.rs
@@ -11,7 +11,7 @@ use std::sync::{
 use tokio::sync::mpsc;
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{info, warn};
 
 pub struct ForwardingTrack {
     track_id: TrackId,
@@ -87,6 +87,7 @@ impl Track for ForwardingTrack {
             .ok_or_else(|| anyhow::anyhow!("forwarding track already started"))?;
         let track_id = self.track_id.clone();
         let cancel_token = self.cancel_token.clone();
+        let mut processor_chain = self.processor_chain.clone();
 
         crate::spawn(async move {
             let stop_reason = loop {
@@ -98,6 +99,9 @@ impl Track for ForwardingTrack {
                         match packet {
                             Some(mut packet) => {
                                 packet.track_id = track_id.clone();
+                                if let Err(e) = processor_chain.process_frame(&mut packet) {
+                                    warn!(track_id, "processor_chain process_frame error: {:?}", e);
+                                }
                                 if packet_sender.send(packet).is_err() {
                                     break "media stream closed";
                                 }


### PR DESCRIPTION
…l was not captured in recorder

Closes #109

get_channel_index pinning is hacky, but otherwise it doesn't work, because server-side-track already took channel 1 for itself, so it wraps around to channel 0, which is the original call. And because of that audio is recorded into single channel and also due to per-channel Mutex locking in the recorder - it's scrambled.