### PR TITLE
fix: recorder not started when specified in Accept for incoming SIP calls

### DIFF
--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -1024,6 +1024,9 @@ impl ActiveCall {
             option = self.invite_or_accept(option, "accept".to_string()).await?;
         } else {
             option.check_default();
+            if let Some(opt) = self.build_record_option(&option) {
+                self.media_stream.update_recorder_option(opt).await;
+            }
             self.call_state.write().await.option = Some(option.clone());
         }
         info!(session_id = self.session_id, ?option, "accepting call");

--- a/src/media/recorder.rs
+++ b/src/media/recorder.rs
@@ -3,7 +3,6 @@ use audio_codec::{PcmBuf, samples_to_bytes};
 use futures::StreamExt;
 use serde::{Deserialize, Serialize};
 use std::{
-    collections::HashMap,
     path::Path,
     sync::{
         Mutex,
@@ -115,8 +114,6 @@ pub struct Recorder {
     option: RecorderOption,
     samples_written: AtomicUsize,
     cancel_token: CancellationToken,
-    channel_idx: AtomicUsize,
-    channels: Mutex<HashMap<String, usize>>,
     stereo_buf: Mutex<PcmBuf>,
     mono_buf: Mutex<PcmBuf>,
 }
@@ -132,8 +129,6 @@ impl Recorder {
             option,
             samples_written: AtomicUsize::new(0),
             cancel_token,
-            channel_idx: AtomicUsize::new(0),
-            channels: Mutex::new(HashMap::new()),
             stereo_buf: Mutex::new(Vec::new()),
             mono_buf: Mutex::new(Vec::new()),
         }
@@ -351,22 +346,10 @@ impl Recorder {
     }
 
     fn get_channel_index(&self, track_id: &str) -> usize {
-        if track_id.starts_with("bridge:") {
-            return 1;
-        }
-        let mut channels = self.channels.lock().unwrap();
-        if let Some(&channel_idx) = channels.get(track_id) {
-            channel_idx % 2
+        if track_id == self.session_id.as_str() {
+            0
         } else {
-            let new_idx = self.channel_idx.fetch_add(1, Ordering::SeqCst);
-            channels.insert(track_id.to_string(), new_idx);
-            info!(
-                session_id = self.session_id,
-                "Assigned channel {} to track: {}",
-                new_idx % 2,
-                track_id
-            );
-            new_idx % 2
+            1
         }
     }
 

--- a/src/media/stream.rs
+++ b/src/media/stream.rs
@@ -437,6 +437,13 @@ impl MediaStream {
                 }
             });
             *self.recorder_handle.lock().await = Some(recorder_handle);
+
+            // Inject RecorderProcessor into tracks that were added before the recorder started
+            for (track, _) in self.tracks.lock().await.values_mut() {
+                track.insert_processor(Box::new(RecorderProcessor::new(
+                    self.recorder_sender.clone(),
+                )));
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Root Cause

Three separate bugs combined to break recording on this path:

**1. Recorder never started (`do_accept`)**
For incoming SIP calls, the SIP stack pre-processes the call via `prepare_incoming_sip_track` before `Accept` arrives, setting `ready_to_answer`. When `do_accept` saw `ready_to_answer` already populated, it took the `else` branch which only stored the option — it never called `build_record_option` / `update_recorder_option`, so the recorder task was never spawned.

**2. Existing tracks missed `RecorderProcessor` (`start_recorder`)**
Even after fixing 1, channel 0 remained silent. `start_recorder` only spawns the recorder task — it never injects `RecorderProcessor` into tracks that are already live. The RTP track for the original call is added during `prepare_incoming_sip_track` (before `Accept` and before the recorder starts), so it never had a processor attached and sent no audio to the recorder.

**3. Channel assignment was non-deterministic (`Recorder::get_channel_index`)**
Channel assignment was first-come-first-served. For WebRTC the ordering happened to be consistent (original call track first), but for SIP the server-side track (TTS/playback) could win the race and land on channel 0, scrambling the stereo layout.

## Fix

- **`do_accept`**: call `build_record_option` / `update_recorder_option` in the `ready_to_answer` branch, mirroring what `invite_or_accept` already does.
- **`start_recorder`**: after spawning the recorder task, iterate all existing tracks and inject `RecorderProcessor` retroactively.
- **`Recorder::get_channel_index`**: replace dynamic assignment with a deterministic rule — channel 0 if `track_id == session_id` (original call), channel 1 for everything else. Removes the now-unnecessary `channel_idx` counter and `channels` HashMap.