### PR TITLE
feat: Automatic Gain Control (AGC) processor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ ogg = "0.9"
 unicode-normalization = "0.1"
 rand_distr = "0.6.0"
 num_cpus = "1.16"
+sonora-agc2 = "0.1.0"
 
 [dev-dependencies]
 tempfile = "3.23.0"

--- a/docs/api.md
+++ b/docs/api.md
@@ -241,6 +241,7 @@ The `mediaPass` option in `CallOption` configures the WebSocket connection for a
     "callee": "sip:agent@rustpbx.com",
     "codec": "pcmu",
     "denoise": true,
+    "agc": {},
     "mediaPass": {
       "url": "ws://ai-voice-processor.rustpbx.com:8090/stream",
       "inputSampleRate": 8000,
@@ -499,6 +500,7 @@ Resume continues paused server-side file/TTS playback from the paused playback p
 - `callee` (string): Address of Record (AOR) of the transfer target (e.g., sip:bob@rustpbx.com)
 - `options` (ReferOption, optional): Transfer configuration
   - `denoise` (boolean, optional): Enable noise reduction
+  - `agc` (AGCOption, optional): Enable Automatic Gain Control (AGC); use `{}` for defaults
   - `timeout` (number, optional): Transfer timeout in seconds
   - `moh` (string, optional): Music on hold URL to play during transfer
   - `asr` (TranscriptionOption, optional): Automatic Speech Recognition configuration
@@ -521,6 +523,7 @@ Resume continues paused server-side file/TTS playback from the paused playback p
   "callee": "sip:charlie@rustpbx.com",
   "options": {
     "denoise": true,
+    "agc": {},
     "timeout": 30,
     "moh": "http://rustpbx.com/hold_music.wav",
     "asr": {
@@ -666,6 +669,7 @@ The `CallOption` object is used in `invite` and `accept` commands and contains t
 ```json
 {
   "denoise": true,
+  "agc": {},
   "offer": "SDP offer string",
   "callee": "sip:callee@rustpbx.com",
   "caller": "sip:caller@rustpbx.com",
@@ -753,6 +757,7 @@ The `CallOption` object is used in `invite` and `accept` commands and contains t
 
 **CallOption Fields:**
 - `denoise` (boolean, optional): Enable noise reduction for audio processing
+- `agc` (AGCOption, optional): Enable Automatic Gain Control (AGC); use `{}` for defaults or specify fields
 - `offer` (string, optional): SDP offer string for WebRTC/SIP negotiation
 - `callee` (string, optional): Callee's SIP URI or phone number (e.g., "sip:bob@rustpbx.com")
 - `caller` (string, optional): Caller's SIP URI or phone number (e.g., "sip:alice@rustpbx.com")
@@ -772,6 +777,14 @@ The `CallOption` object is used in `invite` and `accept` commands and contains t
   - `endpoint` (string, optional): Custom ASR service endpoint URL
   - `extra` (object, optional): Additional provider-specific parameters
   - `startWhenAnswer` (boolean, optional): Start ASR when call is answered
+- `agc` (AGCOption, optional): Automatic Gain Control configuration (WebRTC AGC2); use `{}` for defaults. Requires `vad` to be configured upstream — AGC reads the per-frame speech probability written by the VAD.
+  - `headroomDb` (number, optional): Target headroom below 0 dBFS in dB (default: 5.0)
+  - `maxGainDb` (number, optional): Maximum gain in dB (default: 50.0)
+  - `initialGainDb` (number, optional): Initial gain in dB applied before the speech-level estimator is confident (default: 15.0)
+  - `maxGainChangeDbPerSecond` (number, optional): Maximum gain change in dB per second — controls both attack and release (default: 6.0)
+  - `maxOutputNoiseLevelDbfs` (number, optional): Noise floor cap in dBFS above which AGC will not amplify (default: -50.0)
+  - `adjacentSpeechFramesThreshold` (number, optional): Number of consecutive 10 ms speech sub-frames required before gain increase is allowed (default: 12, ≈120 ms)
+  - `enableLimiter` (boolean, optional): Run the soft-knee limiter after the adaptive gain stage (default: true)
 - `vad` (VADOption, optional): Voice Activity Detection configuration
   - `type` (string): VAD algorithm type ("silero")
   - `samplerate` (number): Audio sample rate for VAD processing (default: 16000)
@@ -860,6 +873,7 @@ The `ReferOption` object is used in the `refer` command and contains the followi
 
 **Fields:**
 - `denoise` (boolean, optional): Enable noise reduction during transfer
+- `agc` (AGCOption, optional): Enable Automatic Gain Control (AGC); use `{}` for defaults or specify fields
 - `timeout` (number, optional): Transfer timeout in seconds
 - `moh` (string, optional): Music on hold URL to play during transfer
 - `asr` (TranscriptionOption, optional): Automatic Speech Recognition configuration

--- a/docs/en/playbook_tutorial.md
+++ b/docs/en/playbook_tutorial.md
@@ -40,6 +40,7 @@ llm:
 ```yaml
 greeting: "Hello, I am your AI assistant. How can I help you today?"
 denoise: true # Enable noise reduction
+agc: {} # Enable WebRTC AGC2 Automatic Gain Control (5 dB headroom, 15 dB initial gain). Requires `vad` to be set.
 interruption:
   strategy: "both" # Strategies: "none", "vad", "asr", "both"
   minSpeechMs: 500 # User must speak for at least 500ms to trigger interruption

--- a/docs/playbook_tutorial.en.md
+++ b/docs/playbook_tutorial.en.md
@@ -40,6 +40,7 @@ llm:
 ```yaml
 greeting: "Hello, I am your AI assistant. How can I help you today?"
 denoise: true # Enable noise reduction
+agc: {} # Enable WebRTC AGC2 Automatic Gain Control (5 dB headroom, 15 dB initial gain). Requires `vad` to be set.
 interruption:
   strategy: "both" # Strategies: "none", "vad", "asr", "both"
   minSpeechMs: 500 # User must speak for at least 500ms to trigger interruption

--- a/docs/playbook_tutorial.zh.md
+++ b/docs/playbook_tutorial.zh.md
@@ -40,6 +40,7 @@ llm:
 ```yaml
 greeting: "您好，我是您的 AI 助手，请问有什么可以帮您？"
 denoise: true # 启用语音降噪
+agc: {} # 启用 WebRTC AGC2 自动增益控制（默认 5 dB 余量，15 dB 初始增益），需要同时配置 `vad`
 interruption:
   strategy: "both" # 打断策略: "none", "vad", "asr", "both"
   minSpeechMs: 500 # 用户说话超过 500ms 才触发打断

--- a/docs/zh/playbook_tutorial.md
+++ b/docs/zh/playbook_tutorial.md
@@ -40,6 +40,7 @@ llm:
 ```yaml
 greeting: "您好，我是您的 AI 助手，请问有什么可以帮您？"
 denoise: true # 启用语音降噪
+agc: {} # 启用 WebRTC AGC2 自动增益控制（默认 5 dB 余量，15 dB 初始增益），需要同时配置 `vad`
 interruption:
   strategy: "both" # 打断策略: "none", "vad", "asr", "both"
   minSpeechMs: 500 # 用户说话超过 500ms 才触发打断

--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -1527,6 +1527,7 @@ impl ActiveCall {
                     opts
                 }),
             denoise: refer_option.as_ref().and_then(|o| o.denoise.clone()),
+            agc: refer_option.as_ref().and_then(|o| o.agc.clone()),
             recorder,
             ..Default::default()
         };
@@ -2762,6 +2763,9 @@ impl ActiveCallState {
             }
             if option.denoise.is_none() {
                 option.denoise = existing.denoise;
+            }
+            if option.agc.is_none() {
+                option.agc = existing.agc.clone();
             }
             if option.recorder.is_none() {
                 option.recorder = existing.recorder.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,10 @@ use std::collections::HashMap;
 
 use crate::{
     media::{
-        ambiance::AmbianceOption, recorder::RecorderOption, track::media_pass::MediaPassOption,
+        agc::AGCOption,
+        ambiance::AmbianceOption,
+        recorder::RecorderOption,
+        track::media_pass::MediaPassOption,
         vad::VADOption,
     },
     synthesis::SynthesisOption,
@@ -50,6 +53,7 @@ pub struct SipOption {
 #[serde(rename_all = "camelCase")]
 pub struct CallOption {
     pub denoise: Option<bool>,
+    pub agc: Option<AGCOption>,
     pub offer: Option<String>,
     pub callee: Option<String>,
     pub caller: Option<String>,
@@ -77,6 +81,7 @@ impl Default for CallOption {
     fn default() -> Self {
         Self {
             denoise: None,
+            agc: None,
             offer: None,
             callee: None,
             caller: None,
@@ -172,6 +177,7 @@ impl CallOption {
 #[serde(rename_all = "camelCase")]
 pub struct ReferOption {
     pub denoise: Option<bool>,
+    pub agc: Option<AGCOption>,
     pub timeout: Option<u32>,
     pub moh: Option<String>,
     pub vad: Option<VADOption>,

--- a/src/media/agc.rs
+++ b/src/media/agc.rs
@@ -1,0 +1,235 @@
+use crate::media::{AudioFrame, Sample, Samples, processor::Processor};
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
+use sonora_agc2::adaptive_digital_gain_controller::{AdaptiveDigitalGainController, FrameInfo};
+use sonora_agc2::common::{
+    ADJACENT_SPEECH_FRAMES_THRESHOLD, FRAME_DURATION_MS, MIN_LEVEL_DBFS,
+    SATURATION_PROTECTOR_INITIAL_HEADROOM_DB, float_s16_to_dbfs,
+};
+use sonora_agc2::limiter::Limiter;
+use sonora_agc2::noise_level_estimator::NoiseLevelEstimator;
+use sonora_agc2::saturation_protector::SaturationProtector;
+use sonora_agc2::speech_level_estimator::{AdaptiveDigitalConfig, SpeechLevelEstimator};
+
+// AGC2 processes audio in fixed 10ms sub-frames.
+const SUB_FRAME_MS: u32 = FRAME_DURATION_MS as u32;
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+#[serde(default)]
+pub struct AGCOption {
+    /// Target headroom below 0 dBFS in dB. AGC2 default: 5.0.
+    pub headroom_db: Option<f32>,
+    /// Maximum gain in dB. AGC2 default: 50.0.
+    pub max_gain_db: Option<f32>,
+    /// Initial gain applied before the speech level estimator becomes confident. AGC2 default: 15.0.
+    pub initial_gain_db: Option<f32>,
+    /// Max gain change in dB per second (attack/release rate). AGC2 default: 6.0.
+    pub max_gain_change_db_per_second: Option<f32>,
+    /// Noise floor cap above which AGC2 will not amplify. AGC2 default: -50.0.
+    pub max_output_noise_level_dbfs: Option<f32>,
+    /// Number of consecutive speech sub-frames required before allowing gain increase. AGC2 default: 12 (≈120 ms).
+    pub adjacent_speech_frames_threshold: Option<i32>,
+    /// Run the limiter after the adaptive gain. Default: true.
+    pub enable_limiter: Option<bool>,
+}
+
+impl Default for AGCOption {
+    fn default() -> Self {
+        Self {
+            headroom_db: None,
+            max_gain_db: None,
+            initial_gain_db: None,
+            max_gain_change_db_per_second: None,
+            max_output_noise_level_dbfs: None,
+            adjacent_speech_frames_threshold: None,
+            enable_limiter: None,
+        }
+    }
+}
+
+pub struct AutomaticGainControl {
+    sample_rate: u32,
+    sub_frame_samples: usize,
+    level_estimator: SpeechLevelEstimator,
+    saturation_protector: SaturationProtector,
+    noise_estimator: NoiseLevelEstimator,
+    controller: AdaptiveDigitalGainController,
+    limiter: Option<Limiter>,
+    f32_buf: Vec<f32>,
+    leftover: Vec<i16>,
+    last_speech_probability: f32,
+    last_applied_gain_linear: f32,
+}
+
+impl AutomaticGainControl {
+    pub fn new(sample_rate: u32, option: AGCOption) -> Result<Self> {
+        let config = AdaptiveDigitalConfig {
+            headroom_db: option.headroom_db.unwrap_or(5.0),
+            max_gain_db: option.max_gain_db.unwrap_or(50.0),
+            initial_gain_db: option.initial_gain_db.unwrap_or(15.0),
+            max_gain_change_db_per_second: option.max_gain_change_db_per_second.unwrap_or(6.0),
+            max_output_noise_level_dbfs: option.max_output_noise_level_dbfs.unwrap_or(-50.0),
+        };
+        let adjacent_threshold = option
+            .adjacent_speech_frames_threshold
+            .unwrap_or(ADJACENT_SPEECH_FRAMES_THRESHOLD);
+
+        let sub_frame_samples = (sample_rate as usize * SUB_FRAME_MS as usize) / 1000;
+        if sub_frame_samples == 0 || sub_frame_samples % 20 != 0 {
+            anyhow::bail!(
+                "sample rate {sample_rate} produces {sub_frame_samples} samples per 10ms, must be > 0 and divisible by 20"
+            );
+        }
+
+        let level_estimator = SpeechLevelEstimator::new(&config, adjacent_threshold);
+        let saturation_protector =
+            SaturationProtector::new(SATURATION_PROTECTOR_INITIAL_HEADROOM_DB, adjacent_threshold);
+        let noise_estimator = NoiseLevelEstimator::default();
+        let controller = AdaptiveDigitalGainController::new(config, adjacent_threshold);
+        let limiter = match option.enable_limiter.unwrap_or(true) {
+            true => Some(Limiter::new(sub_frame_samples)),
+            false => None,
+        };
+
+        Ok(Self {
+            sample_rate,
+            sub_frame_samples,
+            level_estimator,
+            saturation_protector,
+            noise_estimator,
+            controller,
+            limiter,
+            f32_buf: vec![0.0; sub_frame_samples],
+            leftover: Vec::with_capacity(sub_frame_samples),
+            last_speech_probability: 0.0,
+            last_applied_gain_linear: 1.0,
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current_gain_for_test(&self) -> f32 {
+        self.last_applied_gain_linear
+    }
+
+    fn process_sub_frame(&mut self, sub_frame_i16: &mut [i16]) {
+        debug_assert_eq!(sub_frame_i16.len(), self.sub_frame_samples);
+
+        // Convert i16 -> S16-float (range [-32768, 32767]).
+        for (dst, src) in self.f32_buf.iter_mut().zip(sub_frame_i16.iter()) {
+            *dst = *src as f32;
+        }
+
+        let speech_probability = self.last_speech_probability;
+
+        let mut peak_abs = 0.0_f32;
+        let mut sum_sq = 0.0_f32;
+        for &s in self.f32_buf.iter() {
+            peak_abs = peak_abs.max(s.abs());
+            sum_sq += s * s;
+        }
+        let rms_lin = (sum_sq / self.f32_buf.len() as f32).sqrt();
+        // Clamp to satisfy SpeechLevelEstimator debug asserts on silent frames.
+        let rms_dbfs = float_s16_to_dbfs(rms_lin).clamp(MIN_LEVEL_DBFS, 30.0);
+        let peak_dbfs = float_s16_to_dbfs(peak_abs).clamp(MIN_LEVEL_DBFS, 30.0);
+
+        self.level_estimator.update(rms_dbfs, speech_probability);
+        self.saturation_protector.analyze(
+            speech_probability,
+            peak_dbfs,
+            self.level_estimator.level_dbfs(),
+        );
+
+        let mono_view: [&[f32]; 1] = [&self.f32_buf];
+        let noise_rms_dbfs = self.noise_estimator.analyze(&mono_view);
+
+        let limiter_envelope_dbfs = self
+            .limiter
+            .as_ref()
+            .map(|l| l.last_audio_level())
+            .unwrap_or(MIN_LEVEL_DBFS);
+
+        let info = FrameInfo {
+            speech_probability,
+            speech_level_dbfs: self.level_estimator.level_dbfs(),
+            speech_level_reliable: self.level_estimator.is_confident(),
+            noise_rms_dbfs,
+            headroom_db: self.saturation_protector.headroom_db(),
+            limiter_envelope_dbfs,
+        };
+
+        // Sample a non-zero input to estimate the applied linear gain after the
+        // adaptive controller. Stored so tests can read back the gain decision
+        // independently of the input level.
+        let probe_idx = self
+            .f32_buf
+            .iter()
+            .position(|&s| s.abs() > 1.0)
+            .unwrap_or(0);
+        let probe_in = self.f32_buf[probe_idx];
+
+        let mut channels: [&mut [f32]; 1] = [&mut self.f32_buf];
+        self.controller.process(&info, &mut channels);
+
+        if probe_in.abs() > 1.0 {
+            self.last_applied_gain_linear = self.f32_buf[probe_idx] / probe_in;
+        }
+
+        if let Some(limiter) = self.limiter.as_mut() {
+            let mut channels: [&mut [f32]; 1] = [&mut self.f32_buf];
+            limiter.process(&mut channels);
+        }
+
+        // Convert back to i16 with saturating cast.
+        for (dst, src) in sub_frame_i16.iter_mut().zip(self.f32_buf.iter()) {
+            *dst = src.clamp(i16::MIN as f32, i16::MAX as f32) as Sample;
+        }
+    }
+}
+
+impl Processor for AutomaticGainControl {
+    fn process_frame(&mut self, frame: &mut AudioFrame) -> Result<()> {
+        let samples = match &mut frame.samples {
+            Samples::PCM { samples } if !samples.is_empty() => samples,
+            _ => return Ok(()),
+        };
+
+        if frame.sample_rate != self.sample_rate {
+            // Frame from an unexpected rate; pass-through.
+            return Ok(());
+        }
+
+        if let Some(p) = frame.speech_probability {
+            self.last_speech_probability = p.clamp(0.0, 1.0);
+        }
+
+        // Accumulate input into sub-frame-sized chunks. The leftover buffer
+        // carries samples across frames so a 20ms input becomes two 10ms
+        // AGC2 sub-frames cleanly.
+        let mut work = std::mem::take(samples);
+        let mut produced: Vec<i16> = Vec::with_capacity(work.len() + self.leftover.len());
+
+        if !self.leftover.is_empty() {
+            let mut combined = std::mem::take(&mut self.leftover);
+            combined.append(&mut work);
+            work = combined;
+        }
+
+        let mut idx = 0;
+        while idx + self.sub_frame_samples <= work.len() {
+            let end = idx + self.sub_frame_samples;
+            self.process_sub_frame(&mut work[idx..end]);
+            produced.extend_from_slice(&work[idx..end]);
+            idx = end;
+        }
+
+        if idx < work.len() {
+            self.leftover.extend_from_slice(&work[idx..]);
+        }
+
+        *samples = produced;
+        Ok(())
+    }
+}

--- a/src/media/engine.rs
+++ b/src/media/engine.rs
@@ -1,5 +1,6 @@
 use super::{
     INTERNAL_SAMPLERATE,
+    agc::AutomaticGainControl,
     asr_processor::AsrProcessor,
     denoiser::NoiseReducer,
     processor::Processor,
@@ -323,6 +324,11 @@ impl StreamEngine {
                     processors.push(vad_processor);
                 }
                 None => {}
+            }
+            if let Some(agc_option) = option.agc.clone() {
+                debug!(%track_id, "Adding AutomaticGainControl processor");
+                let agc = AutomaticGainControl::new(INTERNAL_SAMPLERATE as u32, agc_option)?;
+                processors.push(Box::new(agc) as Box<dyn Processor>);
             }
             match option.asr {
                 Some(mut option) => {

--- a/src/media/mod.rs
+++ b/src/media/mod.rs
@@ -8,6 +8,7 @@ pub mod dtmf;
 pub mod engine;
 pub mod inactivity;
 pub mod loader;
+pub mod agc;
 pub mod negotiate;
 pub mod processor;
 pub mod realtime_processor;
@@ -53,6 +54,8 @@ pub struct AudioFrame {
     pub timestamp: u64,
     pub sample_rate: u32,
     pub channels: u16,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub speech_probability: Option<f32>,
 }
 
 impl Samples {

--- a/src/media/processor.rs
+++ b/src/media/processor.rs
@@ -35,6 +35,7 @@ impl Default for AudioFrame {
             sample_rate: 16000,
             channels: 1,
             src_packet: None,
+            speech_probability: None,
         }
     }
 }

--- a/src/media/stream.rs
+++ b/src/media/stream.rs
@@ -223,7 +223,7 @@ impl MediaStream {
     pub async fn update_track(&self, mut track: Box<dyn Track>, play_id: Option<String>) {
         self.remove_track(track.id(), false).await;
         if self.recorder_option.lock().await.is_some() {
-            track.insert_processor(Box::new(RecorderProcessor::new(
+            track.append_processor(Box::new(RecorderProcessor::new(
                 self.recorder_sender.clone(),
             )));
         }

--- a/src/media/tests/agc.rs
+++ b/src/media/tests/agc.rs
@@ -1,0 +1,149 @@
+use audio_codec::samples_to_bytes;
+
+use crate::media::{
+    AudioFrame, Samples, agc::{AGCOption, AutomaticGainControl}, processor::Processor,
+};
+use std::{fs::File, io::Write};
+
+#[test]
+fn test_basic_processing() {
+    let (all_samples, sample_rate) =
+        crate::media::track::file::read_wav_file("fixtures/hello_book_course_zh_16k.wav").unwrap();
+    let mut agc = AutomaticGainControl::new(sample_rate, AGCOption::default()).unwrap();
+    let mut out_file = File::create("fixtures/hello_book_course_zh_16k_agc.pcm.decoded").unwrap();
+    let frame_size = (sample_rate as usize) / 50; // 20ms
+    for chunk in all_samples.chunks(frame_size) {
+        let mut frame = AudioFrame {
+            samples: Samples::PCM {
+                samples: chunk.to_vec(),
+            },
+            sample_rate,
+            track_id: "test".to_string(),
+            timestamp: 0,
+            channels: 1,
+            src_packet: None,
+            ..Default::default()
+        };
+        agc.process_frame(&mut frame).unwrap();
+        let samples = match frame.samples {
+            Samples::PCM { samples } => samples,
+            _ => panic!("Expected PCM samples"),
+        };
+        out_file.write_all(&samples_to_bytes(&samples)).unwrap();
+    }
+    println!(
+        "ffplay -f s16le -ar {} fixtures/hello_book_course_zh_16k_agc.pcm.decoded",
+        sample_rate
+    );
+}
+
+#[test]
+fn test_silence_does_not_pump_gain() {
+    // Feed quiet speech to settle gain above 1.0, then feed pure silence
+    // followed by low-level noise — gain must not be driven up during silence.
+    let sample_rate = 16000u32;
+    let frame_size = 320; // 20ms
+
+    let mut agc = AutomaticGainControl::new(sample_rate, AGCOption::default()).unwrap();
+
+    // ~2s of quiet 200Hz sine at amplitude 3000 (~-20 dBFS peak)
+    let amplitude = 3000.0;
+    let freq = 200.0;
+    let speech_frames = 100;
+    for i in 0..speech_frames {
+        let mut samples = Vec::with_capacity(frame_size);
+        for n in 0..frame_size {
+            let t = ((i * frame_size + n) as f32) / sample_rate as f32;
+            let v = (amplitude * (2.0 * std::f32::consts::PI * freq * t).sin()) as i16;
+            samples.push(v);
+        }
+        let mut frame = make_frame(samples, sample_rate);
+        agc.process_frame(&mut frame).unwrap();
+    }
+
+    // Snapshot gain after speech
+    let gain_after_speech = agc.current_gain_for_test();
+
+    // ~3s of pure silence — must not pump gain up
+    for _ in 0..150 {
+        let mut frame = make_frame(vec![0i16; frame_size], sample_rate);
+        agc.process_frame(&mut frame).unwrap();
+    }
+    let gain_after_silence = agc.current_gain_for_test();
+
+    // ~3s of low-level noise (-60 dBFS, below silence threshold) — must also not pump
+    let noise_amp = (i16::MAX as f32 * 10f32.powf(-60.0 / 20.0)) as i16;
+    for i in 0..150 {
+        let mut samples = Vec::with_capacity(frame_size);
+        for n in 0..frame_size {
+            // alternating ± to keep peak ~= noise_amp
+            let s = if (i + n) % 2 == 0 { noise_amp } else { -noise_amp };
+            samples.push(s);
+        }
+        let mut frame = make_frame(samples, sample_rate);
+        agc.process_frame(&mut frame).unwrap();
+    }
+    let gain_after_noise = agc.current_gain_for_test();
+
+    println!(
+        "gains: speech={:.3} silence={:.3} noise={:.3}",
+        gain_after_speech, gain_after_silence, gain_after_noise
+    );
+
+    // Gain must not climb during silent stretches (allow tiny smoothing drift).
+    assert!(
+        gain_after_silence <= gain_after_speech + 0.01,
+        "gain drifted up during silence: {} -> {}",
+        gain_after_speech,
+        gain_after_silence
+    );
+    assert!(
+        gain_after_noise <= gain_after_speech + 0.01,
+        "gain drifted up during sub-threshold noise: {} -> {}",
+        gain_after_speech,
+        gain_after_noise
+    );
+}
+
+#[test]
+fn test_agc_performance() {
+    if cfg!(debug_assertions) {
+        println!("Skipping AGC performance test in debug mode.");
+        return;
+    }
+    use std::time::Instant;
+    let sample_rate = 16000u32;
+    let frame_size = 320; // 20ms at 16kHz
+    let mut agc = AutomaticGainControl::new(sample_rate, AGCOption::default()).unwrap();
+
+    let mut samples = Vec::with_capacity(frame_size);
+    for i in 0..frame_size {
+        samples.push((i % 100) as i16);
+    }
+
+    let iterations = 5000;
+    let start = Instant::now();
+
+    for _ in 0..iterations {
+        let mut frame = make_frame(samples.clone(), sample_rate);
+        agc.process_frame(&mut frame).unwrap();
+    }
+
+    let duration = start.elapsed();
+    let avg_time = duration / iterations as u32;
+
+    println!("Total time for {} iterations: {:?}", iterations, duration);
+    println!("Average time per frame: {:?}", avg_time);
+    println!("FPS: {:.2}", 1.0 / avg_time.as_secs_f64());
+}
+
+fn make_frame(samples: Vec<i16>, sample_rate: u32) -> AudioFrame {
+    AudioFrame {
+        samples: Samples::PCM { samples },
+        sample_rate,
+        track_id: "test".to_string(),
+        timestamp: 0,
+        channels: 1,
+        ..Default::default()
+    }
+}

--- a/src/media/tests/mod.rs
+++ b/src/media/tests/mod.rs
@@ -1,4 +1,5 @@
 mod denoiser;
+mod agc;
 mod file_track;
 mod media_pass;
 mod perf_analysis;

--- a/src/media/vad/mod.rs
+++ b/src/media/vad/mod.rs
@@ -120,6 +120,12 @@ pub struct VadProcessor {
 
 pub trait VadEngine: Send + Sync + Any {
     fn process(&mut self, frame: &mut AudioFrame) -> Vec<(bool, u64)>;
+
+    /// Latest raw speech probability in [0, 1] from the underlying model.
+    /// Returns None for engines that don't produce a probability (e.g. NopVad).
+    fn last_probability(&self) -> Option<f32> {
+        None
+    }
 }
 
 impl VadProcessorInner {
@@ -131,6 +137,7 @@ impl VadProcessorInner {
 
         let samples_cloned = samples.to_owned();
         let results = self.vad.process(frame);
+        frame.speech_probability = self.vad.last_probability();
         for (is_speaking, timestamp) in results {
             if is_speaking || self.triggered {
                 let current_buf = SpeechBuf {

--- a/src/media/vad/tiny_silero.rs
+++ b/src/media/vad/tiny_silero.rs
@@ -228,6 +228,7 @@ pub struct SileroSession {
     current_timestamp: u64,
     processed_samples: u64,
     initialized_timestamp: bool,
+    last_score: Option<f32>,
 }
 
 impl SileroSession {
@@ -260,6 +261,7 @@ impl SileroSession {
             current_timestamp: 0,
             processed_samples: 0,
             initialized_timestamp: false,
+            last_score: None,
         }
     }
 }
@@ -536,6 +538,10 @@ impl TinySilero {
 }
 
 impl VadEngine for TinySilero {
+    fn last_probability(&self) -> Option<f32> {
+        self.session.last_score
+    }
+
     fn process(&mut self, frame: &mut AudioFrame) -> Vec<(bool, u64)> {
         let samples = match &frame.samples {
             Samples::PCM { samples } => samples,
@@ -565,6 +571,7 @@ impl VadEngine for TinySilero {
             let score = self.predict(&chunk_f32);
 
             self.session.buf_chunk_f32 = chunk_f32;
+            self.session.last_score = Some(score);
 
             let is_voice = score > self.config.voice_threshold;
 

--- a/src/playbook/mod.rs
+++ b/src/playbook/mod.rs
@@ -1,3 +1,4 @@
+use crate::media::agc::AGCOption;
 use crate::media::recorder::RecorderOption;
 use crate::media::vad::VADOption;
 use crate::synthesis::SynthesisOption;
@@ -48,6 +49,7 @@ pub struct PlaybookConfig {
     pub llm: Option<LlmConfig>,
     pub vad: Option<VADOption>,
     pub denoise: Option<bool>,
+    pub agc: Option<AGCOption>,
     pub ambiance: Option<AmbianceOption>,
     pub recorder: Option<RecorderOption>,
     pub extra: Option<HashMap<String, String>>,

--- a/src/playbook/runner.rs
+++ b/src/playbook/runner.rs
@@ -263,6 +263,9 @@ pub fn apply_playbook_config(option: &mut CallOption, config: &PlaybookConfig) {
     if let Some(denoise) = config.denoise {
         option.denoise = Some(denoise);
     }
+    if let Some(agc) = config.agc.clone() {
+        option.agc = Some(agc);
+    }
     if let Some(ambiance) = config.ambiance.clone() {
         option.ambiance = Some(ambiance);
     }

--- a/tests/asr_pause_resume_test.rs
+++ b/tests/asr_pause_resume_test.rs
@@ -34,6 +34,7 @@ async fn test_refer_option_pause_parent_asr_field() {
         sip: None,
         call_id: None,
         forward_dtmf: None,
+        agc: None,
     };
 
     assert_eq!(refer_option.pause_parent_asr, Some(true));
@@ -49,6 +50,7 @@ async fn test_refer_option_pause_parent_asr_field() {
         sip: None,
         call_id: None,
         forward_dtmf: None,
+        agc: None,
     };
 
     assert_eq!(refer_option_false.pause_parent_asr, Some(false));
@@ -65,6 +67,7 @@ async fn test_refer_option_pause_parent_asr_field() {
         sip: None,
         call_id: None,
         forward_dtmf: None,
+        agc: None,
     };
     assert_eq!(none_refer.pause_parent_asr, None);
 }
@@ -143,6 +146,7 @@ async fn test_refer_option_serialization() -> Result<()> {
         sip: None,
         call_id: None,
         forward_dtmf: None,
+        agc: None,
     };
 
     let json = serde_json::to_string(&refer_option)?;

--- a/tests/hold_asr_continuity_test.rs
+++ b/tests/hold_asr_continuity_test.rs
@@ -24,6 +24,7 @@ async fn test_hold_processor_continues_frame_flow() -> Result<()> {
         sample_rate: 16000,
         channels: 1,
         src_packet: None,
+        ..Default::default()
     };
 
     // Process the frame (in hold state)
@@ -75,6 +76,7 @@ async fn test_hold_processor_continues_frame_flow() -> Result<()> {
         sample_rate: 16000,
         channels: 1,
         src_packet: None,
+        ..Default::default()
     };
 
     processor.process_frame(&mut frame2)?;
@@ -117,6 +119,7 @@ async fn test_hold_with_empty_frame() -> Result<()> {
         sample_rate: 16000,
         channels: 1,
         src_packet: None,
+        ..Default::default()
     };
 
     // Should not panic with empty samples
@@ -149,6 +152,7 @@ async fn test_hold_with_non_pcm_samples() -> Result<()> {
         sample_rate: 16000,
         channels: 1,
         src_packet: None,
+        ..Default::default()
     };
 
     processor.process_frame(&mut frame)?;


### PR DESCRIPTION
Closes https://github.com/miuda-ai/active-call/issues/114

## Summary

Adds a per-call Automatic Gain Control stage to the media chain, ported from WebRTC's AGC2 via the `sonora-agc2` crate. Stabilizes loudness across callers without the pumping artifacts of envelope compressors and without the warmup lag of an EBU R128 short-term meter.

Enable with `agc: {}` on `CallOption`, `ReferOption`, or playbook config — every parameter is individually overridable.

## What's new

- **AGC processor** (`src/media/agc.rs`) wiring AGC2's `SpeechLevelEstimator` → `SaturationProtector` → `NoiseLevelEstimator` → `AdaptiveDigitalGainController` → `Limiter`. 20 ms i16 mono frames are converted to S16-float and split into 10 ms AGC2 sub-frames, with a leftover buffer for non-divisible inputs.
- **`AudioFrame.speech_probability: Option<f32>`** carries the VAD's per-frame sigmoid score down the processor chain.
- **`VadEngine::last_probability()`** trait method (default `None`). `TinySilero` stores its last predict score and exposes it; `VadProcessor` writes the value into the frame after each invocation.
- **Processor order** is now `denoise → VAD → AGC → ASR`, so AGC reads the speech probability the VAD just wrote.
- **Recorder placement** changed from `insert_processor` to `append_processor` in `MediaStream`, so recordings capture the post-AGC signal instead of raw mic audio.

## Configuration

Defaults mirror AGC2's `AdaptiveDigitalConfig`:

| Field | Default | Meaning |
| --- | --- | --- |
| `headroomDb` | 5.0 | Target headroom below 0 dBFS |
| `maxGainDb` | 50.0 | Maximum applied gain |
| `initialGainDb` | 15.0 | Gain before the level estimator is confident |
| `maxGainChangeDbPerSecond` | 6.0 | Attack/release rate |
| `maxOutputNoiseLevelDbfs` | -50.0 | Noise floor cap — won't amplify above this |
| `adjacentSpeechFramesThreshold` | 12 | ~120 ms of confident speech required before gain increase |
| `enableLimiter` | true | Run the soft-knee limiter after the adaptive stage |

`vad` must be configured upstream; without it, AGC sees `speech_probability = None`, treats every frame as non-speech, and holds at `initialGainDb`.

## Why not the EBU R128 approach we started with

The earlier short-term-loudness implementation needed 3 s before it could amplify, and a separate silence gate to stop the smoother from drifting during pauses. AGC2 doesn't need either:

- Adjacent-speech-frames gate blocks gain increase until ~120 ms of confident speech is seen.
- The level estimator weights samples by speech probability, so ambient noise can't pull the target up.
- Saturation protector tracks the crest factor between recent peaks and the speech level and dynamically adjusts headroom to avoid clipping.