### PR TITLE
feat: graceful shutdown waits for active calls to finish naturally

### DIFF
--- a/active-call.example.toml
+++ b/active-call.example.toml
@@ -39,6 +39,14 @@ media_cache_path = "./config/mediacache"
 # enable_ice_lite = false
 # rtp_bind_ip = 0.0.0.0
 
+# Graceful shutdown: on SIGTERM/Ctrl-C, stop accepting new calls and wait for
+# in-progress calls to finish before exiting.
+# graceful_shutdown = true
+#
+# Total seconds to wait during graceful shutdown before forcing exit.
+# SIP de-registration and active call draining run in parallel, both with this timeout.
+# graceful_shutdown_timeout = 30
+
 # setup your STUN/TURN servers here, for webrtc web clients
 # [[ice_servers]]
 # urls = ["stun:stun.l.google.com:19302"]

--- a/src/app.rs
+++ b/src/app.rs
@@ -26,7 +26,7 @@ use chrono::{DateTime, Local};
 use futures::FutureExt;
 use humantime::parse_duration;
 use rsipstack::rsip::prelude::HeadersExt;
-use rsipstack::rsip::{typed, Accept, Method};
+use rsipstack::rsip::{Accept, Method, typed};
 use rsipstack::transaction::{
     Endpoint, TransactionReceiver,
     endpoint::{TargetLocator, TransportEventInspector},
@@ -193,12 +193,11 @@ impl AppStateInner {
             },
         }
 
-        // Wait for registration to stop, if not stopped within 50 seconds,
-        // force stop it.
+        let total_secs = self.config.graceful_shutdown_timeout.unwrap_or(30);
         let timeout = self
             .config
             .graceful_shutdown
-            .map(|_| Duration::from_secs(10));
+            .map(|_| Duration::from_secs(total_secs));
 
         match self.stop_registration(timeout).await {
             Ok(_) => {
@@ -379,13 +378,12 @@ impl AppStateInner {
                         let _pending_guard = guard;
                         let token_ref = token.clone();
                         let accept_timeout_sleep = tokio::time::sleep(accept_timeout);
-                        let invite_handler = invitation_handler
-                            .on_invite(
-                                dialog_id_str.clone(),
-                                token.clone(),
-                                dialog.clone(),
-                                routing_state,
-                            );
+                        let invite_handler = invitation_handler.on_invite(
+                            dialog_id_str.clone(),
+                            token.clone(),
+                            dialog.clone(),
+                            routing_state,
+                        );
                         let dialog_handle = dialog_ref.handle(&mut tx);
                         tokio::pin!(accept_timeout_sleep);
                         tokio::pin!(invite_handler);
@@ -475,8 +473,7 @@ impl AppStateInner {
                                             "error rejecting invite: {:?}", e
                                         );
                                     }
-                                    invitation_for_cleanup
-                                        .get_pending_call(&dialog_id_for_cleanup);
+                                    invitation_for_cleanup.get_pending_call(&dialog_id_for_cleanup);
                                     invitation_for_cleanup
                                         .dialog_layer
                                         .remove_dialog(&dialog_id_for_cleanup);
@@ -542,20 +539,45 @@ impl AppStateInner {
         self.token.cancel();
     }
 
-    pub async fn graceful_stop(&self) -> Result<()> {
+    pub async fn graceful_stop(&self, total_timeout_secs: u64) -> Result<()> {
         if self.shutting_down.swap(true, Ordering::Relaxed) {
             return Ok(());
         }
 
         info!("graceful stopping, marking as shutting down");
-        let timeout = self
-            .config
-            .graceful_shutdown
-            .map(|_| Duration::from_secs(10));
+        let timeout = Duration::from_secs(total_timeout_secs);
 
-        self.stop_registration(timeout).await?;
+        let (reg_result, ()) = tokio::join!(
+            self.stop_registration(Some(timeout)),
+            self.wait_for_active_calls(timeout),
+        );
+        if let Err(e) = reg_result {
+            warn!("stop_registration error: {}", e);
+        }
         self.token.cancel();
         Ok(())
+    }
+
+    async fn wait_for_active_calls(&self, timeout: Duration) {
+        let active_calls = self.active_calls.clone();
+        let check_loop = async move {
+            let mut last_count = usize::MAX;
+            loop {
+                let count = active_calls.lock().unwrap().len();
+                if count == 0 {
+                    break;
+                }
+                if count != last_count {
+                    info!(active_calls = count, "waiting for active calls to finish");
+                    last_count = count;
+                }
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        };
+        match tokio::time::timeout(timeout, check_loop).await {
+            Ok(()) => info!("all active calls finished"),
+            Err(_) => warn!("timed out waiting for active calls to finish, forcing shutdown"),
+        }
     }
 
     pub async fn start_registration(&self) -> Result<usize> {
@@ -619,7 +641,9 @@ impl AppStateInner {
                     rsipstack::rsip::Host::Domain(domain) => domain.to_string(),
                     rsipstack::rsip::Host::IpAddr(ip) => {
                         // Compare IP addresses
-                        if let rsipstack::rsip::Host::IpAddr(callee_ip) = &parsed_callee.host_with_port.host {
+                        if let rsipstack::rsip::Host::IpAddr(callee_ip) =
+                            &parsed_callee.host_with_port.host
+                        {
                             if ip == callee_ip {
                                 if let Some(cred) = &option.credential {
                                     info!(
@@ -666,7 +690,9 @@ impl AppStateInner {
                 }
 
                 if let Ok(parsed_server) = rsipstack::rsip::Uri::try_from(server.as_str()) {
-                    if let rsipstack::rsip::Host::IpAddr(server_ip) = &parsed_server.host_with_port.host {
+                    if let rsipstack::rsip::Host::IpAddr(server_ip) =
+                        &parsed_server.host_with_port.host
+                    {
                         if server_ip == callee_ip {
                             if let Some(cred) = &option.credential {
                                 info!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,6 +94,10 @@ fn default_graceful_shutdown() -> Option<bool> {
     Some(true)
 }
 
+fn default_graceful_shutdown_timeout() -> Option<u64> {
+    Some(30)
+}
+
 fn default_config_useragent() -> Option<String> {
     Some(format!(
         "active-call({} miuda.ai)",
@@ -188,6 +192,10 @@ pub struct Config {
     pub register_users: Option<Vec<RegisterOption>>,
     #[serde(default = "default_graceful_shutdown")]
     pub graceful_shutdown: Option<bool>,
+    /// Total seconds to wait during graceful shutdown before forcing exit.
+    /// SIP de-registration and active call draining run in parallel, both with this timeout.
+    #[serde(default = "default_graceful_shutdown_timeout")]
+    pub graceful_shutdown_timeout: Option<u64>,
     pub handler: Option<InviteHandlerConfig>,
     pub accept_timeout: Option<String>,
     #[serde(default = "default_codecs")]
@@ -305,6 +313,7 @@ impl Default for Config {
             useragent: None,
             register_users: None,
             graceful_shutdown: Some(true),
+            graceful_shutdown_timeout: default_graceful_shutdown_timeout(),
             handler: None,
             accept_timeout: Some("50s".to_string()),
             media_cache_path: default_config_media_cache_path(),

--- a/src/main_builder.rs
+++ b/src/main_builder.rs
@@ -345,6 +345,7 @@ impl MainBuilder {
     ) -> Result<()> {
         let app_state_clone = app_state.clone();
         let graceful_shutdown = self.config.graceful_shutdown.unwrap_or_default();
+        let graceful_shutdown_timeout = self.config.graceful_shutdown_timeout.unwrap_or(30);
 
         let axum_serving = axum::serve(listener, router).into_future();
         let app_state_serving = app_state_clone.serve();
@@ -397,8 +398,8 @@ impl MainBuilder {
                     }
                     if graceful_shutdown {
                         let app_state = app_state.clone();
-                        shutdown_task.set(async move { app_state.graceful_stop().await }.boxed());
-                        *cancel_timeout = tokio::time::sleep(tokio::time::Duration::from_secs(30)).boxed();
+                        shutdown_task.set(async move { app_state.graceful_stop(graceful_shutdown_timeout).await }.boxed());
+                        *cancel_timeout = tokio::time::sleep(tokio::time::Duration::from_secs(graceful_shutdown_timeout)).boxed();
                         canceled = true;
                     } else {
                         break;


### PR DESCRIPTION
On SIGTERM/Ctrl-C, new INVITEs are rejected immediately, then SIP de-registration and active-call draining run in parallel. The process only exits (or force-kills after timeout) once both complete.

Adds `graceful_shutdown_timeout` config field (default 30s) to control the wait budget, replacing the previously hardcoded 30s outer deadline.