### PR TITLE
feat(media): cache decoded PCM instead of original audio files

### DIFF
--- a/src/media/cache.rs
+++ b/src/media/cache.rs
@@ -3,8 +3,11 @@ use bytes::BytesMut;
 use once_cell::sync::Lazy;
 use sha2::{Digest, Sha256};
 use std::sync::RwLock;
-use std::{io::IoSlice, path::PathBuf};
-use tokio::io::AsyncReadExt;
+use std::{
+    io::{IoSlice, SeekFrom},
+    path::PathBuf,
+};
+use tokio::io::{AsyncReadExt, AsyncSeekExt};
 use tokio::{fs::create_dir_all, io::AsyncWriteExt};
 use tracing::{debug, info};
 
@@ -129,7 +132,24 @@ pub async fn store_pcm_in_cache(key: &str, samples: &[i16]) -> Result<()> {
 
 /// Retrieve decoded PCM samples (i16) from the cache stored as raw little-endian bytes
 pub async fn retrieve_pcm_from_cache(key: &str) -> Result<Vec<i16>> {
-    let bytes = retrieve_from_cache(key).await?;
+    retrieve_pcm_from_cache_at(key, 0).await
+}
+
+/// Retrieve decoded PCM samples (i16) from the cache starting at `sample_offset`
+/// samples in, seeking past the skipped bytes instead of reading them.
+pub async fn retrieve_pcm_from_cache_at(key: &str, sample_offset: usize) -> Result<Vec<i16>> {
+    let path = get_cache_path(key)?;
+    let mut file = tokio::fs::File::open(&path).await?;
+    let file_size = file.metadata().await?.len();
+    let byte_offset = ((sample_offset as u64) * 2).min(file_size);
+    if byte_offset > 0 {
+        file.seek(SeekFrom::Start(byte_offset)).await?;
+    }
+
+    let remaining = (file_size - byte_offset) as usize;
+    let mut bytes = Vec::with_capacity(remaining);
+    file.read_to_end(&mut bytes).await?;
+
     if bytes.len() % 2 != 0 {
         return Err(anyhow!(
             "cache: pcm data length {} is not aligned to i16 for key: {}",
@@ -209,6 +229,31 @@ mod tests {
         // Test clean cache
         let key2 = generate_cache_key("test_data2", 16000, None, None);
         store_in_cache(&key2, &test_data).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_pcm_cache_roundtrip_and_offset() -> Result<()> {
+        let key = generate_cache_key("test_pcm_offset", 16000, None, None);
+        delete_from_cache(&key).await.ok();
+
+        let samples: Vec<i16> = (0..1000i16).collect();
+        store_pcm_in_cache(&key, &samples).await?;
+
+        // Full retrieval matches what we stored.
+        let full = retrieve_pcm_from_cache(&key).await?;
+        assert_eq!(full, samples);
+
+        // Offset retrieval matches slicing the full buffer.
+        let offset = 250;
+        let tail = retrieve_pcm_from_cache_at(&key, offset).await?;
+        assert_eq!(tail, samples[offset..]);
+
+        // Offset past the end yields an empty buffer rather than erroring.
+        let empty = retrieve_pcm_from_cache_at(&key, samples.len() + 100).await?;
+        assert!(empty.is_empty());
+
+        delete_from_cache(&key).await?;
         Ok(())
     }
 

--- a/src/media/cache.rs
+++ b/src/media/cache.rs
@@ -118,6 +118,32 @@ pub async fn store_in_cache_vectored(key: &str, data: &[impl AsRef<[u8]>]) -> Re
     Ok(())
 }
 
+/// Store decoded PCM samples (i16) in the cache as raw little-endian bytes
+pub async fn store_pcm_in_cache(key: &str, samples: &[i16]) -> Result<()> {
+    let mut bytes = Vec::with_capacity(samples.len() * 2);
+    for sample in samples {
+        bytes.extend_from_slice(&sample.to_le_bytes());
+    }
+    store_in_cache(key, &bytes).await
+}
+
+/// Retrieve decoded PCM samples (i16) from the cache stored as raw little-endian bytes
+pub async fn retrieve_pcm_from_cache(key: &str) -> Result<Vec<i16>> {
+    let bytes = retrieve_from_cache(key).await?;
+    if bytes.len() % 2 != 0 {
+        return Err(anyhow!(
+            "cache: pcm data length {} is not aligned to i16 for key: {}",
+            bytes.len(),
+            key
+        ));
+    }
+    let samples = bytes
+        .chunks_exact(2)
+        .map(|b| i16::from_le_bytes([b[0], b[1]]))
+        .collect();
+    Ok(samples)
+}
+
 /// Retrieve data from the cache
 pub async fn retrieve_from_cache(key: &str) -> Result<Vec<u8>> {
     let path = get_cache_path(key)?;

--- a/src/media/loader.rs
+++ b/src/media/loader.rs
@@ -354,6 +354,69 @@ pub fn decode_audio(
     Ok(all_samples)
 }
 
+/// Load audio from a path/URL, decode it to PCM at `target_sample_rate`, and
+/// cache the *decoded* PCM (not the original encoded file) so subsequent loads
+/// skip downloading and decoding entirely.
+pub async fn load_audio_as_pcm_cached(
+    path: &str,
+    target_sample_rate: u32,
+    use_cache: bool,
+) -> Result<Vec<i16>> {
+    let cache_key = cache::generate_cache_key(path, target_sample_rate, None, None);
+
+    if use_cache && cache::is_cached(&cache_key).await? {
+        match cache::retrieve_pcm_from_cache(&cache_key).await {
+            Ok(samples) => {
+                info!(
+                    "loader: loaded {} decoded samples from pcm cache for {}",
+                    samples.len(),
+                    path
+                );
+                return Ok(samples);
+            }
+            Err(e) => warn!("loader: failed to read pcm cache for {}: {}", path, e),
+        }
+    }
+
+    let is_url = path.starts_with("http://") || path.starts_with("https://");
+
+    // Download/open the original file without caching the encoded bytes; we
+    // cache the decoded PCM below instead.
+    let (file, content_type) = if is_url {
+        download_from_url(path, false).await?
+    } else {
+        (
+            File::open(path).map_err(|e| anyhow!("loader: {} {}", path, e))?,
+            None,
+        )
+    };
+
+    let extension = if is_url {
+        path.parse::<Url>()?
+            .path()
+            .split('.')
+            .last()
+            .unwrap_or("")
+            .to_string()
+    } else {
+        path.split('.').last().unwrap_or("").to_string()
+    };
+
+    // Decoding is CPU-bound and blocking; keep it off the async runtime.
+    let samples = tokio::task::spawn_blocking(move || {
+        decode_audio(file, &extension, content_type.as_deref(), target_sample_rate)
+    })
+    .await??;
+
+    if use_cache {
+        if let Err(e) = cache::store_pcm_in_cache(&cache_key, &samples).await {
+            warn!("loader: failed to store pcm cache for {}: {}", path, e);
+        }
+    }
+
+    Ok(samples)
+}
+
 pub async fn load_audio_as_pcm(
     path: &str,
     target_sample_rate: u32,

--- a/src/media/loader.rs
+++ b/src/media/loader.rs
@@ -357,20 +357,27 @@ pub fn decode_audio(
 /// Load audio from a path/URL, decode it to PCM at `target_sample_rate`, and
 /// cache the *decoded* PCM (not the original encoded file) so subsequent loads
 /// skip downloading and decoding entirely.
+///
+/// `offset_ms` skips that much audio from the start of the returned PCM. The
+/// full decoded PCM is still cached (the offset is not part of the cache key);
+/// on a cache hit only the bytes after the offset are read from disk.
 pub async fn load_audio_as_pcm_cached(
     path: &str,
     target_sample_rate: u32,
     use_cache: bool,
+    offset_ms: u32,
 ) -> Result<Vec<i16>> {
     let cache_key = cache::generate_cache_key(path, target_sample_rate, None, None);
+    let offset_samples = (offset_ms as usize * target_sample_rate as usize) / 1000;
 
     if use_cache && cache::is_cached(&cache_key).await? {
-        match cache::retrieve_pcm_from_cache(&cache_key).await {
+        match cache::retrieve_pcm_from_cache_at(&cache_key, offset_samples).await {
             Ok(samples) => {
                 info!(
-                    "loader: loaded {} decoded samples from pcm cache for {}",
+                    "loader: loaded {} decoded samples from pcm cache for {} (offset {} ms)",
                     samples.len(),
-                    path
+                    path,
+                    offset_ms
                 );
                 return Ok(samples);
             }
@@ -403,16 +410,20 @@ pub async fn load_audio_as_pcm_cached(
     };
 
     // Decoding is CPU-bound and blocking; keep it off the async runtime.
-    let samples = tokio::task::spawn_blocking(move || {
+    let mut samples = tokio::task::spawn_blocking(move || {
         decode_audio(file, &extension, content_type.as_deref(), target_sample_rate)
     })
     .await??;
 
+    // Cache the full decoded PCM before applying the offset.
     if use_cache {
         if let Err(e) = cache::store_pcm_in_cache(&cache_key, &samples).await {
             warn!("loader: failed to store pcm cache for {}: {}", path, e);
         }
     }
+
+    let skip = offset_samples.min(samples.len());
+    samples.drain(..skip);
 
     Ok(samples)
 }

--- a/src/media/track/file.rs
+++ b/src/media/track/file.rs
@@ -1,10 +1,7 @@
 use crate::event::{EventSender, SessionEvent};
 use crate::media::processor::ProcessorChain;
 use crate::media::{AudioFrame, PcmBuf, Samples, TrackId};
-use crate::media::{
-    cache,
-    track::{Track, TrackConfig, TrackPacketSender},
-};
+use crate::media::track::{Track, TrackConfig, TrackPacketSender};
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use audio_codec::Resampler;
@@ -21,7 +18,6 @@ use tokio::select;
 use tokio::time::Duration;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, info, warn};
-use url::Url;
 
 trait AudioReader: Send {
     fn fill_buffer(&mut self) -> Result<usize>;
@@ -85,6 +81,7 @@ struct DecodedAudioReader {
 }
 
 impl DecodedAudioReader {
+    #[cfg(test)]
     fn from_file(
         file: File,
         extension: &str,
@@ -100,6 +97,19 @@ impl DecodedAudioReader {
             target_sample_rate,
             resampler: None,
         })
+    }
+
+    /// Build a reader from already-decoded PCM samples. The samples are assumed
+    /// to already be at `sample_rate`, so no further resampling happens when it
+    /// matches `target_sample_rate`.
+    fn from_samples(buffer: Vec<i16>, sample_rate: u32, target_sample_rate: u32) -> Self {
+        Self {
+            buffer,
+            sample_rate,
+            position: 0,
+            target_sample_rate,
+            resampler: None,
+        }
     }
 }
 
@@ -353,37 +363,18 @@ impl Track for FileTrack {
         let play_id = self.play_id.clone();
         crate::spawn(async move {
             let res = async move {
-                let is_url = path.starts_with("http://") || path.starts_with("https://");
-
-                let extension = if is_url {
-                    path.parse::<Url>()?.path().split('.').last().unwrap_or("").to_string()
-                } else {
-                    path.split('.').last().unwrap_or("").to_string()
-                };
-
-                let cache_key = if is_url {
-                    Some(cache::generate_cache_key(&path, 0, None, None))
-                } else {
-                    None
-                };
-
-                // Open file or download from URL
-                let open_result = if is_url {
-                    crate::media::loader::download_from_url(&path, use_cache).await
-                } else {
-                    File::open(&path)
-                        .map(|f| (f, None))
-                        .map_err(|e| anyhow::anyhow!("filetrack: {}", e))
-                };
-                let (file, content_type) = match open_result {
-                    Ok(result) => result,
+                // Load (and cache) the decoded PCM so we don't re-download or
+                // re-decode the original file on every play.
+                let load_result = crate::media::loader::load_audio_as_pcm_cached(
+                    &path,
+                    sample_rate,
+                    use_cache,
+                )
+                .await;
+                let samples = match load_result {
+                    Ok(samples) => samples,
                     Err(e) => {
-                        warn!("filetrack: Error opening file: {}", e);
-                        if let Some(key) = cache_key {
-                            if use_cache {
-                                let _ = cache::delete_from_cache(&key).await;
-                            }
-                        }
+                        warn!("filetrack: Error loading audio: {} {}", path, e);
                         event_sender
                             .send(SessionEvent::Error {
                                 track_id: id.clone(),
@@ -406,14 +397,12 @@ impl Track for FileTrack {
                     }
                 };
 
-                // Stream the audio file
-                let stream_result = stream_audio_file(
+                // Stream the decoded PCM
+                let stream_result = stream_pcm_samples(
                     processor_chain,
-                    extension.as_str(),
-                    content_type.as_deref(),
-                    file,
-                    &id,
+                    samples,
                     sample_rate,
+                    &id,
                     packet_duration_ms,
                     offset_ms,
                     token,
@@ -425,11 +414,6 @@ impl Track for FileTrack {
                 // Handle any streaming errors
                 if let Err(e) = stream_result {
                     warn!("filetrack: Error streaming audio: {}, {}", path, e);
-                    if let Some(key) = cache_key {
-                        if use_cache {
-                            let _ = cache::delete_from_cache(&key).await;
-                        }
-                    }
                     event_sender
                         .send(SessionEvent::Error {
                             track_id: id.clone(),
@@ -473,42 +457,28 @@ impl Track for FileTrack {
     }
 }
 
-// Helper function to stream a WAV or MP3 file
-async fn stream_audio_file(
+// Helper function to stream already-decoded PCM samples
+async fn stream_pcm_samples(
     processor_chain: ProcessorChain,
-    extension: &str,
-    content_type: Option<&str>,
-    file: File,
-    track_id: &str,
+    samples: Vec<i16>,
     target_sample_rate: u32,
+    track_id: &str,
     packet_duration_ms: u32,
     offset_ms: u32,
     token: CancellationToken,
     paused: Arc<AtomicBool>,
     packet_sender: TrackPacketSender,
 ) -> Result<()> {
-    let start_time = Instant::now();
-    let extension_owned = extension.to_string();
-    let content_type_owned = content_type.map(|s| s.to_string());
-    let reader = tokio::task::spawn_blocking(move || {
-        DecodedAudioReader::from_file(
-            file,
-            &extension_owned,
-            content_type_owned.as_deref(),
-            target_sample_rate,
-        )
-    })
-    .await??;
+    let reader =
+        DecodedAudioReader::from_samples(samples, target_sample_rate, target_sample_rate);
     let mut audio_reader = Box::new(reader) as Box<dyn AudioReader>;
     info!(
-        "filetrack: Load file duration: {:.2} seconds, sample rate: {} Hz, extension: {}",
-        start_time.elapsed().as_secs_f64(),
+        "filetrack: streaming {} decoded samples at {} Hz",
+        audio_reader.buffer_size(),
         audio_reader.sample_rate(),
-        extension
     );
     if offset_ms > 0 {
-        let offset_samples =
-            (offset_ms as usize * audio_reader.sample_rate() as usize) / 1000;
+        let offset_samples = (offset_ms as usize * audio_reader.sample_rate() as usize) / 1000;
         audio_reader.set_position(offset_samples.min(audio_reader.buffer_size()));
     }
     process_audio_reader(
@@ -576,6 +546,7 @@ pub fn read_wav_file(path: &str) -> Result<(PcmBuf, u32)> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::media::cache;
     use crate::media::cache::ensure_cache_dir;
     use std::io::Write;
     use tokio::sync::{broadcast, mpsc};
@@ -722,15 +693,9 @@ mod tests {
         // Add a delay to ensure the cache file is written
         tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
 
-        // Get the cache key and verify it exists
+        // The cache key is derived from the path and the target sample rate; the
+        // cached payload should be the decoded PCM, not the original WAV bytes.
         let cache_key = cache::generate_cache_key(&file_path, 16000, None, None);
-        let wav_data = tokio::fs::read(&file_path).await?;
-
-        // Manually store the file in cache if it's not already there, to make the test more reliable
-        if !cache::is_cached(&cache_key).await? {
-            info!("Cache file not found, manually storing it");
-            cache::store_in_cache(&cache_key, &wav_data).await?;
-        }
 
         // Verify cache exists
         assert!(
@@ -738,6 +703,17 @@ mod tests {
             "Cache file should exist for key: {}",
             cache_key
         );
+
+        // The cached PCM should match the freshly decoded PCM and differ from the
+        // original encoded file.
+        let cached_pcm = cache::retrieve_pcm_from_cache(&cache_key).await?;
+        let decoded_pcm =
+            crate::media::loader::load_audio_as_pcm(&file_path, 16000, false).await?;
+        assert_eq!(
+            cached_pcm, decoded_pcm,
+            "cached PCM should match freshly decoded PCM"
+        );
+        assert!(!cached_pcm.is_empty(), "cached PCM should not be empty");
 
         // Allow the test to pass if packets weren't received
         if !received_packet {

--- a/src/media/track/file.rs
+++ b/src/media/track/file.rs
@@ -369,6 +369,7 @@ impl Track for FileTrack {
                     &path,
                     sample_rate,
                     use_cache,
+                    offset_ms,
                 )
                 .await;
                 let samples = match load_result {
@@ -397,14 +398,13 @@ impl Track for FileTrack {
                     }
                 };
 
-                // Stream the decoded PCM
+                // Stream the decoded PCM (offset already applied during load)
                 let stream_result = stream_pcm_samples(
                     processor_chain,
                     samples,
                     sample_rate,
                     &id,
                     packet_duration_ms,
-                    offset_ms,
                     token,
                     paused,
                     packet_sender,
@@ -464,23 +464,18 @@ async fn stream_pcm_samples(
     target_sample_rate: u32,
     track_id: &str,
     packet_duration_ms: u32,
-    offset_ms: u32,
     token: CancellationToken,
     paused: Arc<AtomicBool>,
     packet_sender: TrackPacketSender,
 ) -> Result<()> {
     let reader =
         DecodedAudioReader::from_samples(samples, target_sample_rate, target_sample_rate);
-    let mut audio_reader = Box::new(reader) as Box<dyn AudioReader>;
+    let audio_reader = Box::new(reader) as Box<dyn AudioReader>;
     info!(
         "filetrack: streaming {} decoded samples at {} Hz",
         audio_reader.buffer_size(),
         audio_reader.sample_rate(),
     );
-    if offset_ms > 0 {
-        let offset_samples = (offset_ms as usize * audio_reader.sample_rate() as usize) / 1000;
-        audio_reader.set_position(offset_samples.min(audio_reader.buffer_size()));
-    }
     process_audio_reader(
         processor_chain,
         audio_reader,


### PR DESCRIPTION
FileTrack previously cached the original encoded file (e.g. mp3) under a .pcm key and re-decoded it on every play. Now the decoded, resampled PCM is cached and replayed directly, skipping download and decode on hits.

Useful for offset_ms for "artificial" pausing. (play queue music, inform queue size, "resume" queue music with offset_ms)