### PR TITLE
fix: stop re-invite ACK from poisoning peer connection's remote SDP

### DIFF
--- a/src/call/sip.rs
+++ b/src/call/sip.rs
@@ -611,6 +611,7 @@ mod tests {
             media_stream,
             terminated_reason: None,
             has_early_media,
+            initial_confirmed: false,
             hangup_reason: None,
         }
     }

--- a/src/call/sip.rs
+++ b/src/call/sip.rs
@@ -91,6 +91,14 @@ pub(super) struct InviteDialogStates {
     pub media_stream: Arc<MediaStream>,
     pub terminated_reason: Option<TerminatedReason>,
     pub has_early_media: bool,
+    /// Set once the initial INVITE's answer has been applied via
+    /// `DialogState::Confirmed`. rsipstack reuses the same `Confirmed` event
+    /// for the ACK of a re-INVITE we received (see `handle_reinvite`), but
+    /// in that case the body is the PBX's own locally-generated answer, not
+    /// a remote description — that re-invite was already fully handled via
+    /// `DialogState::Updated`/`handshake()`. Re-applying it here corrupts
+    /// the peer connection's remote SSRC/address with our own values.
+    initial_confirmed: bool,
     /// Hangup intent carried by this leg (refer legs with `auto_hangup`),
     /// reported on the leg's TrackEnd so the call actor can hang up.
     pub hangup_reason: Option<CallRecordHangupReason>,
@@ -117,6 +125,7 @@ impl InviteDialogStates {
             media_stream,
             terminated_reason: None,
             has_early_media: false,
+            initial_confirmed: false,
             hangup_reason,
         }
     }
@@ -210,7 +219,8 @@ impl DialogStateReceiverGuard {
                     states
                         .leg
                         .update_progress(|p| p.on_confirmed(dialog_id.to_string()));
-                    if states.is_client {
+                    if states.is_client && !states.initial_confirmed {
+                        states.initial_confirmed = true;
                         let answer = String::from_utf8_lossy(msg.body());
                         let answer = answer.trim();
                         if !answer.is_empty() {


### PR DESCRIPTION
## Bug

Calls where the SIP peer sends a self re-INVITE right after answering
(e.g. MicroSIP's post-answer ICE-address-update + codec-narrow
re-INVITEs) end up with completely dead RTP for the rest of the call —
not just a brief glitch. TTS played on the leg, but the caller never
heard it, and the audio bridge on the far leg was silent too.

## Root cause

`rsipstack`'s `handle_reinvite` (`invite_dialog.rs`) fires
`DialogState::Confirmed` when the ACK for an incoming re-INVITE
arrives, reusing the same event variant used for the original dialog
establishment — but the body it carries (`tx.last_response`) is the
PBX's own locally-generated 200 OK answer to that re-INVITE, not
something from the remote party.

`active-call`'s `DialogState::Confirmed` handler in `call/sip.rs`
didn't distinguish "the initial INVITE we sent just got answered"
from "ACK arrived for a re-INVITE we already fully handled via
`DialogState::Updated`/`handshake()`". It unconditionally fed the
message body into `update_remote_description()`, so on every
re-INVITE it re-fed the PBX's *own* SDP answer back into rustrtc as if
it were the remote's answer.

That corrupts the peer connection's expected SSRC and remote RTP
address with the PBX's own values (own SSRC, own IP) instead of the
peer's. `IceConn`'s "preserving latched remote" guard only rescues
this by luck (if a real inbound packet happens to have re-latched in
the same instant); when the race is lost, `remote_addr` stays wrong
for the rest of the call since nothing corrects it afterward.

## Fix

Track `initial_confirmed` on `InviteDialogStates` and only apply the
`Confirmed` event's body to `update_remote_description` the first
time — subsequent `Confirmed` events (from re-INVITE ACKs) are
no-ops here, since those re-INVITEs were already handled through the
`Updated`/`handshake()` path.