### PR TITLE
fix: silent ringback during outbound call setup

### DIFF
--- a/src/call/active_call.rs
+++ b/src/call/active_call.rs
@@ -1166,7 +1166,7 @@ impl ActiveCall {
 
     async fn dispatch(&self, runtime: &mut CallRuntime, command: Command) -> Result<()> {
         match command {
-            Command::Invite { option } => self.do_invite(option).await,
+            Command::Invite { option } => self.do_invite(runtime, option).await,
             Command::Accept { option } => self.do_accept(option).await,
             Command::Reject { reason, code } => {
                 self.do_reject(code.map(|c| (c as u16).into()), Some(reason))
@@ -1334,10 +1334,32 @@ impl ActiveCall {
         }
     }
 
-    async fn do_invite(&self, option: CallOption) -> Result<()> {
-        self.invite_or_accept(option, "invite".to_string())
-            .await
-            .map(|_| ())
+    async fn do_invite(&self, runtime: &mut CallRuntime, option: CallOption) -> Result<()> {
+        // Run the INVITE handshake in the background so the actor keeps
+        // serving media (and everything else) while the call rings - same
+        // reasoning as do_refer below. invite_or_accept blocks on the SIP
+        // transaction for the entire ring duration; handling that inline on
+        // the actor's own select loop would freeze media_stream.serve() (and
+        // therefore all live audio bridging for this leg) for just as long.
+        let me = runtime
+            .me
+            .clone()
+            .ok_or_else(|| anyhow::anyhow!("invite is only supported inside serve()"))?;
+        crate::spawn(async move {
+            if let Err(e) = me.invite_or_accept(option, "invite".to_string()).await {
+                warn!(session_id = me.session_id, "{}", e);
+                me.event_sender
+                    .send(SessionEvent::Error {
+                        track_id: me.session_id.clone(),
+                        timestamp: crate::media::get_timestamp(),
+                        sender: "command".to_string(),
+                        error: e.to_string(),
+                        code: None,
+                    })
+                    .ok();
+            }
+        });
+        Ok(())
     }
 
     async fn do_accept(&self, mut option: CallOption) -> Result<()> {

--- a/src/call/sip.rs
+++ b/src/call/sip.rs
@@ -201,7 +201,10 @@ impl DialogStateReceiverGuard {
                         states.leg.update_progress(|p| p.try_set_answer(&answer));
                         states
                             .media_stream
-                            .update_remote_description(&states.track_id, &answer.to_string())
+                            .update_remote_description_provisional(
+                                &states.track_id,
+                                &answer.to_string(),
+                            )
                             .await?;
                     }
                 }

--- a/src/media/stream.rs
+++ b/src/media/stream.rs
@@ -317,6 +317,25 @@ impl MediaStream {
         Ok(())
     }
 
+    /// Apply a provisional remote description (SIP 183 early media). See
+    /// `Track::update_remote_description_provisional`.
+    pub async fn update_remote_description_provisional(
+        &self,
+        track_id: &TrackId,
+        answer: &String,
+    ) -> Result<()> {
+        let track_entry = { self.tracks.lock().await.remove(track_id) };
+        if let Some((mut track, dtmf)) = track_entry {
+            let res = track.update_remote_description_provisional(answer).await;
+            self.tracks
+                .lock()
+                .await
+                .insert(track_id.clone(), (track, dtmf));
+            res?;
+        }
+        Ok(())
+    }
+
     pub async fn handshake(
         &self,
         track_id: &TrackId,

--- a/src/media/track/mod.rs
+++ b/src/media/track/mod.rs
@@ -81,6 +81,13 @@ pub trait Track: Send + Sync {
         // Default implementation: force update is same as regular update for most tracks
         self.update_remote_description(answer).await
     }
+    /// Apply a provisional remote description (SIP 183 early media). Unlike
+    /// `update_remote_description`, this must not finalize SDP negotiation —
+    /// the real answer (200 OK) is still to come. Default: same as a regular
+    /// update, for track types that don't have a signaling state machine.
+    async fn update_remote_description_provisional(&mut self, answer: &String) -> Result<()> {
+        self.update_remote_description(answer).await
+    }
     async fn start(
         &mut self,
         event_sender: EventSender,

--- a/src/media/track/rtc.rs
+++ b/src/media/track/rtc.rs
@@ -583,13 +583,15 @@ impl RtcTrack {
         &mut self,
         answer: &String,
         force_update: bool,
+        sdp_type: rustrtc::SdpType,
     ) -> Result<()> {
         info!(
             track_id=%self.track_id,
-            "update_remote_description_internal called. force={}, last_sdp_is_some={}, mode={:?}",
+            "update_remote_description_internal called. force={}, last_sdp_is_some={}, mode={:?}, sdp_type={:?}",
             force_update,
             self.last_remote_sdp.is_some(),
-            self.rtc_config.mode
+            self.rtc_config.mode,
+            sdp_type
         );
 
         if let Some(pc) = &self.peer_connection {
@@ -606,7 +608,7 @@ impl RtcTrack {
 
             let _is_first_remote_sdp = self.last_remote_sdp.is_none();
 
-            let sdp_obj = rustrtc::SessionDescription::parse(rustrtc::SdpType::Answer, answer)?;
+            let sdp_obj = rustrtc::SessionDescription::parse(sdp_type, answer)?;
             match pc.set_remote_description(sdp_obj.clone()).await {
                 Ok(_) => {
                     debug!(track_id=%self.track_id, "set_remote_description succeeded");
@@ -647,7 +649,7 @@ impl RtcTrack {
             // Track events will be handled by the event loop after SSRC latching
 
             // Extract negotiated payload types from SDP string
-            self.parse_sdp_payload_types(rustrtc::SdpType::Answer, answer)?;
+            self.parse_sdp_payload_types(sdp_type, answer)?;
         }
         Ok(())
     }
@@ -715,11 +717,25 @@ impl Track for RtcTrack {
     }
 
     async fn update_remote_description(&mut self, answer: &String) -> Result<()> {
-        self.update_remote_description_internal(answer, false).await
+        self.update_remote_description_internal(answer, false, rustrtc::SdpType::Answer)
+            .await
     }
 
     async fn update_remote_description_force(&mut self, answer: &String) -> Result<()> {
-        self.update_remote_description_internal(answer, true).await
+        self.update_remote_description_internal(answer, true, rustrtc::SdpType::Answer)
+            .await
+    }
+
+    async fn update_remote_description_provisional(&mut self, answer: &String) -> Result<()> {
+        // SIP 183 early media: apply as a provisional answer so signaling
+        // state stays in HaveLocalOffer, leaving room for the real 200 OK
+        // answer to complete negotiation. Tagging this as a full Answer (as
+        // the final answer does) would move state to Stable early, so the
+        // real answer would then be rejected as an invalid re-application
+        // and only recover via the SDP-mismatch re-sync fallback below —
+        // losing/disrupting the media path for the ringing window.
+        self.update_remote_description_internal(answer, false, rustrtc::SdpType::Pranswer)
+            .await
     }
 
     async fn start(


### PR DESCRIPTION
## Bug

Operators never heard ringback tone while an outbound call (to the
customer/PSTN leg) was ringing, even though the call itself worked
fine once answered. TTS/beep played to the operator normally; only
the far leg's own early-media audio, forwarded through the bridge,
was silent during ringing.

## Root causes (two, both needed)

**1. 183 early media applied as `Answer` instead of `Pranswer`**

`active-call` always tagged the remote SDP as `SdpType::Answer` when
calling into `rustrtc`, including for 183 Session Progress early
media. That moves `rustrtc`'s signaling state from `HaveLocalOffer`
straight to `Stable` during ringing. When the real 200 OK later
arrived with the same SDP, applying it as another `Answer` from
`Stable` is invalid — `rustrtc` rejected it, and `active-call`'s own
SDP-mismatch recovery path silently papered over the error by
fabricating a bogus local re-INVITE offer and reapplying the remote
SDP against that, disrupting the peer connection's transport state
right at the ringing-to-answered boundary.

`rustrtc` has a purpose-built `SdpType::Pranswer` for exactly this
case (its own `set_remote_description` comment names SIP 183 early
media specifically), which `active-call` never used. Fixed by adding
`Track::update_remote_description_provisional` (RtcTrack applies it
as `Pranswer`) and pointing `DialogState::Early`'s handler at it
instead of the `Answer`-tagged path.

**2. Outbound INVITE blocked the call's own actor loop for the whole ring duration**

Fixing (1) surfaced a second, independent bug: `ActiveCall::serve()`'s
actor `tokio::select!` loop handles SIP commands and drives
`media_stream.serve()` (which forwards all live audio, including
bridged ringback) as sibling branches of the *same* loop.
`do_invite` awaited the entire INVITE transaction — including
ringing — inline inside that loop. Since `select!` only re-polls its
arms after the current branch's handler fully returns, this froze
`media_serve` (and therefore all audio forwarding for that leg) for
as long as the callee took to answer.

Confirmed empirically: instrumented the actor loop and measured
`dispatch(Invite)` taking 6689ms to return, matching the dial-to-answer
time to the millisecond, with zero packets forwarded through the
bridge for that entire span.

`do_refer` already works around this identical problem by running its
INVITE handshake on its own spawned task instead of inline. Applied
the same pattern to `do_invite`.