### PR TITLE
fix: outbound INVITE not actually cancelled when hung up while ringing

### DIFF
--- a/src/call/sip.rs
+++ b/src/call/sip.rs
@@ -56,7 +56,21 @@ impl DialogStateReceiverGuard {
     fn take_dialog(&mut self) -> Option<Dialog> {
         let id = self.dialog_id.take()?;
         info!(%id, "dialog removed on  drop");
-        remove_dialog(&self.dialog_layer, &id)
+        if let Some(dialog) = remove_dialog(&self.dialog_layer, &id) {
+            return Some(dialog);
+        }
+        // A client dialog is only re-registered under its tag-bearing id once
+        // do_invite's process_invite() fully completes; while still ringing
+        // it's registered under the pre-response id (empty remote tag). Our
+        // tracked `id` already reflects whatever tag the latest DialogState
+        // event carried (e.g. a 183's), so the exact-key lookup above misses
+        // it for any dialog hung up before it's confirmed. Fall back to a
+        // call-id scan, which is unaffected by that id mutation.
+        self.dialog_layer
+            .get_client_dialog_by_call_id(&id.call_id)
+            .into_iter()
+            .next()
+            .map(Dialog::Invite)
     }
 
     pub async fn drop_async(&mut self) {

--- a/src/call/tracks.rs
+++ b/src/call/tracks.rs
@@ -698,6 +698,28 @@ impl ActiveCall {
             .invite(out.invite_option, dlg_state_sender)
             .await?;
 
+        if out.cancel_token.is_cancelled() {
+            // CANCEL and the far end's 2xx crossed in flight (RFC 3261 S9.1
+            // glare) - e.g. a slow PSTN gateway had already committed to
+            // alerting the handset by the time our CANCEL arrived, and it
+            // answered anyway. do_invite already ACKed the 2xx; per spec we
+            // must now BYE it instead of treating this as a normal answer -
+            // the ActiveCall session this invite belongs to is already gone.
+            if let Some(dialog) = self.invitation.dialog_layer.get_dialog(&dialog_id) {
+                if let Err(e) = dialog.hangup().await {
+                    warn!(
+                        session_id = self.session_id,
+                        "failed to BYE a late-confirmed cancelled invite: {}", e
+                    );
+                }
+            }
+            return Err(rsipstack::Error::DialogError(
+                "invite was cancelled before this late answer arrived".to_string(),
+                dialog_id,
+                rsipstack::rsip::StatusCode::RequestTerminated,
+            ));
+        }
+
         self.set_moh(None);
 
         if let Some(track) = rtp_track_to_setup {


### PR DESCRIPTION
## Bug

Hanging up a call while its outbound leg was still ringing (before
the far end answered) had no effect: the phone kept ringing, and if
it was then answered, the call stayed connected — silently orphaned,
since the ActiveCall session had already ended — until the far end
eventually hung up on its own.

## Root causes (two, both needed)

**1. `DialogStateReceiverGuard` looked up the dialog under the wrong key**

The guard tracks whatever dialog id the latest `DialogState` event
carried — e.g. a 183's, which already has the remote tag filled in.
But rsipstack's `DialogLayer` only re-registers a client dialog under
that tag-bearing id once `do_invite`'s `process_invite()` fully
completes; while still ringing, the dialog is registered only under
its original pre-response id (empty remote tag). So looking it up by
the tracked id during ringing missed every time, and
`hangup_with_headers()` (which sends CANCEL) never actually got
called — hangup silently did nothing until the dialog resolved on its
own.

Fixed by falling back to a call-id scan
(`get_client_dialog_by_call_id`) when the exact-key lookup misses,
since that's unaffected by the tag mutation.

**2. No handling for CANCEL racing a genuine answer**

CANCEL is the correct way to abort an INVITE that hasn't gotten a
final response, but it can race with a real answer — e.g. a slow PSTN
gateway that already committed to alerting the handset before our
CANCEL arrived. RFC 3261 §9.1 covers exactly this: if a `2xx` arrives
despite CANCEL, the UAC must ACK it and then immediately BYE it.
`do_invite` already ACKs, but `create_outgoing_sip_track` had nothing
checking for this, so a late `2xx` was treated as a normal successful
call — it would proceed to set up the RTP track and emit `Answer` for
an invite whose `ActiveCall` session no longer existed.

Fixed by checking the leg's `cancel_token` right after `invite()`
resolves; if it's already cancelled, BYE the just-confirmed dialog
and return an error instead of continuing as if the call had
succeeded.